### PR TITLE
Ffmpeg filters for dldt

### DIFF
--- a/VCA2/centos-7.4/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/centos-7.4/ffmpeg+gst+dev/Dockerfile
@@ -242,8 +242,9 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK && \
     make install;
 
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
@@ -252,6 +253,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -265,6 +267,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib64"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -273,9 +276,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 
@@ -392,13 +395,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q libass-devel freetype-devel SDL2-devel libxcb-devel libvdpau-devel texinfo zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -406,7 +428,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/VCA2/centos-7.4/ffmpeg/Dockerfile
+++ b/VCA2/centos-7.4/ffmpeg/Dockerfile
@@ -249,13 +249,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q SDL2-devel libxcb-devel libvdpau-devel zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \

--- a/VCA2/centos-7.5/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/centos-7.5/ffmpeg+gst+dev/Dockerfile
@@ -242,8 +242,9 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK && \
     make install;
 
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
@@ -252,6 +253,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -265,6 +267,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib64"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -273,9 +276,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 
@@ -392,13 +395,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q libass-devel freetype-devel SDL2-devel libxcb-devel libvdpau-devel texinfo zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -406,7 +428,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/VCA2/centos-7.5/ffmpeg/Dockerfile
+++ b/VCA2/centos-7.5/ffmpeg/Dockerfile
@@ -249,13 +249,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q SDL2-devel libxcb-devel libvdpau-devel zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \

--- a/VCA2/centos-7.6/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/centos-7.6/ffmpeg+gst+dev/Dockerfile
@@ -242,8 +242,9 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK && \
     make install;
 
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
@@ -252,6 +253,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -265,6 +267,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib64"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -273,9 +276,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 
@@ -392,13 +395,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q libass-devel freetype-devel SDL2-devel libxcb-devel libvdpau-devel texinfo zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -406,7 +428,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/VCA2/centos-7.6/ffmpeg/Dockerfile
+++ b/VCA2/centos-7.6/ffmpeg/Dockerfile
@@ -249,13 +249,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q SDL2-devel libxcb-devel libvdpau-devel zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \

--- a/VCA2/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
@@ -236,8 +236,9 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK && \
     make install;
 
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
@@ -245,6 +246,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -258,6 +260,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib/x86_64-linux-gnu"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -266,9 +269,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 
@@ -363,13 +366,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends libass-dev libfreetype6-dev libvdpau-dev libsdl2-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev texinfo zlib1g-dev libssl-dev
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -377,7 +399,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/VCA2/ubuntu-16.04/ffmpeg/Dockerfile
+++ b/VCA2/ubuntu-16.04/ffmpeg/Dockerfile
@@ -243,13 +243,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends libvdpau-dev libsdl2-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev zlib1g-dev libssl-dev
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \

--- a/VCA2/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
@@ -236,8 +236,9 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK && \
     make install;
 
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
@@ -245,6 +246,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -258,6 +260,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib/x86_64-linux-gnu"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -266,9 +269,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 
@@ -364,13 +367,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends libass-dev libfreetype6-dev libvdpau-dev libsdl2-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev texinfo zlib1g-dev libssl-dev
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -378,7 +400,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/VCA2/ubuntu-18.04/ffmpeg/Dockerfile
+++ b/VCA2/ubuntu-18.04/ffmpeg/Dockerfile
@@ -243,13 +243,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends libvdpau-dev libsdl2-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev zlib1g-dev libssl-dev
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \

--- a/Xeon/centos-7.4/dldt+ffmpeg/Dockerfile
+++ b/Xeon/centos-7.4/dldt+ffmpeg/Dockerfile
@@ -192,8 +192,9 @@ RUN git clone ${SVT_VP9_REPO} && \
 
 #include(transform360.m4)
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
@@ -202,6 +203,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -215,6 +217,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib64"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -223,11 +226,23 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
+
+# Build librdkafka
+ARG LIBRDKAFKA_VER=0.11.6
+ARG FILE_NAME=v${LIBRDKAFKA_VER}
+ARG LIBRDKAFKA_REPO=https://github.com/edenhill/librdkafka/archive/${FILE_NAME}.tar.gz
+
+RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
+    cd librdkafka-${LIBRDKAFKA_VER} && \
+    ./configure --prefix=/usr --libdir=/usr/lib64 && \
+    make -j8 && \
+    make install DESTDIR=/home/build && \
+    make install;
 
 # Fetch FFmpeg source
 ARG FFMPEG_VER=n4.1
@@ -235,13 +250,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -249,7 +283,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl  --disable-xlib --disable-sdl2 --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl  --disable-xlib --disable-sdl2 --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine --enable-librdkafka  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/Xeon/centos-7.4/dldt+ffmpeg/Dockerfile.m4
+++ b/Xeon/centos-7.4/dldt+ffmpeg/Dockerfile.m4
@@ -18,6 +18,7 @@ include(svt-av1.m4)
 include(svt-vp9.m4)
 #include(transform360.m4)
 include(dldt-ie.m4)
+include(librdkafka.m4)
 include(ffmpeg.m4)
 include(cleanup.m4)dnl
 

--- a/Xeon/centos-7.4/dldt+gst/Dockerfile
+++ b/Xeon/centos-7.4/dldt+gst/Dockerfile
@@ -191,8 +191,9 @@ RUN git clone ${SVT_VP9_REPO} && \
     make install )
 
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
@@ -201,6 +202,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -214,6 +216,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib64"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -222,9 +225,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 

--- a/Xeon/centos-7.4/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/centos-7.4/ffmpeg+gst+dev/Dockerfile
@@ -192,8 +192,9 @@ RUN git clone ${SVT_VP9_REPO} && \
 
 #include(transform360.m4)
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
@@ -202,6 +203,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -215,6 +217,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib64"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -223,9 +226,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 
@@ -317,13 +320,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q libass-devel freetype-devel SDL2-devel libxcb-devel texinfo zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -331,7 +353,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/Xeon/centos-7.4/ffmpeg/Dockerfile
+++ b/Xeon/centos-7.4/ffmpeg/Dockerfile
@@ -197,13 +197,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \

--- a/Xeon/centos-7.4/ospray/Dockerfile
+++ b/Xeon/centos-7.4/ospray/Dockerfile
@@ -8,31 +8,31 @@ RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-c
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
-RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz; \
-    cd cmake-${CMAKE_VER}; \
-    ./bootstrap --prefix="/usr"; \
-    make -j8; \
+RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
+    cd cmake-${CMAKE_VER} && \
+    ./bootstrap --prefix="/usr" && \
+    make -j8 && \
     make install
 
 # Build NASM
 ARG NASM_VER=2.13.03
 ARG NASM_REPO=https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VER}/nasm-${NASM_VER}.tar.bz2
-RUN  wget ${NASM_REPO}; \
-     tar -xaf nasm*; \
-     cd nasm-${NASM_VER}; \
-     ./autogen.sh; \
-     ./configure --prefix="/usr" --libdir=/usr/lib64; \
-     make -j8; \
+RUN  wget ${NASM_REPO} && \
+     tar -xaf nasm* && \
+     cd nasm-${NASM_VER} && \
+     ./autogen.sh && \
+     ./configure --prefix="/usr" --libdir=/usr/lib64 && \
+     make -j8 && \
      make install
 
 # Build YASM
 ARG YASM_VER=1.3.0
 ARG YASM_REPO=https://www.tortall.net/projects/yasm/releases/yasm-${YASM_VER}.tar.gz
-RUN  wget -O - ${YASM_REPO} | tar xz; \
-     cd yasm-${YASM_VER}; \
-     sed -i "s/) ytasm.*/)/" Makefile.in; \
-     ./configure --prefix="/usr" --libdir=/usr/lib64; \
-     make -j8; \
+RUN  wget -O - ${YASM_REPO} | tar xz && \
+     cd yasm-${YASM_VER} && \
+     sed -i "s/) ytasm.*/)/" Makefile.in && \
+     ./configure --prefix="/usr" --libdir=/usr/lib64 && \
+     make -j8 && \
      make install
 
 #build ISPC

--- a/Xeon/centos-7.5/dldt+ffmpeg/Dockerfile
+++ b/Xeon/centos-7.5/dldt+ffmpeg/Dockerfile
@@ -192,8 +192,9 @@ RUN git clone ${SVT_VP9_REPO} && \
 
 #include(transform360.m4)
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
@@ -202,6 +203,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -215,6 +217,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib64"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -223,11 +226,23 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
+
+# Build librdkafka
+ARG LIBRDKAFKA_VER=0.11.6
+ARG FILE_NAME=v${LIBRDKAFKA_VER}
+ARG LIBRDKAFKA_REPO=https://github.com/edenhill/librdkafka/archive/${FILE_NAME}.tar.gz
+
+RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
+    cd librdkafka-${LIBRDKAFKA_VER} && \
+    ./configure --prefix=/usr --libdir=/usr/lib64 && \
+    make -j8 && \
+    make install DESTDIR=/home/build && \
+    make install;
 
 # Fetch FFmpeg source
 ARG FFMPEG_VER=n4.1
@@ -235,13 +250,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -249,7 +283,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl  --disable-xlib --disable-sdl2 --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl  --disable-xlib --disable-sdl2 --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine --enable-librdkafka  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/Xeon/centos-7.5/dldt+ffmpeg/Dockerfile.m4
+++ b/Xeon/centos-7.5/dldt+ffmpeg/Dockerfile.m4
@@ -18,6 +18,7 @@ include(svt-av1.m4)
 include(svt-vp9.m4)
 #include(transform360.m4)
 include(dldt-ie.m4)
+include(librdkafka.m4)
 include(ffmpeg.m4)
 include(cleanup.m4)dnl
 

--- a/Xeon/centos-7.5/dldt+gst/Dockerfile
+++ b/Xeon/centos-7.5/dldt+gst/Dockerfile
@@ -191,8 +191,9 @@ RUN git clone ${SVT_VP9_REPO} && \
     make install )
 
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
@@ -201,6 +202,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -214,6 +216,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib64"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -222,9 +225,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 

--- a/Xeon/centos-7.5/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/centos-7.5/ffmpeg+gst+dev/Dockerfile
@@ -192,8 +192,9 @@ RUN git clone ${SVT_VP9_REPO} && \
 
 #include(transform360.m4)
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
@@ -202,6 +203,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -215,6 +217,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib64"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -223,9 +226,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 
@@ -317,13 +320,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q libass-devel freetype-devel SDL2-devel libxcb-devel texinfo zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -331,7 +353,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/Xeon/centos-7.5/ffmpeg/Dockerfile
+++ b/Xeon/centos-7.5/ffmpeg/Dockerfile
@@ -197,13 +197,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \

--- a/Xeon/centos-7.5/ospray/Dockerfile
+++ b/Xeon/centos-7.5/ospray/Dockerfile
@@ -8,31 +8,31 @@ RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-c
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
-RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz; \
-    cd cmake-${CMAKE_VER}; \
-    ./bootstrap --prefix="/usr"; \
-    make -j8; \
+RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
+    cd cmake-${CMAKE_VER} && \
+    ./bootstrap --prefix="/usr" && \
+    make -j8 && \
     make install
 
 # Build NASM
 ARG NASM_VER=2.13.03
 ARG NASM_REPO=https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VER}/nasm-${NASM_VER}.tar.bz2
-RUN  wget ${NASM_REPO}; \
-     tar -xaf nasm*; \
-     cd nasm-${NASM_VER}; \
-     ./autogen.sh; \
-     ./configure --prefix="/usr" --libdir=/usr/lib64; \
-     make -j8; \
+RUN  wget ${NASM_REPO} && \
+     tar -xaf nasm* && \
+     cd nasm-${NASM_VER} && \
+     ./autogen.sh && \
+     ./configure --prefix="/usr" --libdir=/usr/lib64 && \
+     make -j8 && \
      make install
 
 # Build YASM
 ARG YASM_VER=1.3.0
 ARG YASM_REPO=https://www.tortall.net/projects/yasm/releases/yasm-${YASM_VER}.tar.gz
-RUN  wget -O - ${YASM_REPO} | tar xz; \
-     cd yasm-${YASM_VER}; \
-     sed -i "s/) ytasm.*/)/" Makefile.in; \
-     ./configure --prefix="/usr" --libdir=/usr/lib64; \
-     make -j8; \
+RUN  wget -O - ${YASM_REPO} | tar xz && \
+     cd yasm-${YASM_VER} && \
+     sed -i "s/) ytasm.*/)/" Makefile.in && \
+     ./configure --prefix="/usr" --libdir=/usr/lib64 && \
+     make -j8 && \
      make install
 
 #build ISPC

--- a/Xeon/centos-7.6/dldt+ffmpeg/Dockerfile
+++ b/Xeon/centos-7.6/dldt+ffmpeg/Dockerfile
@@ -192,8 +192,9 @@ RUN git clone ${SVT_VP9_REPO} && \
 
 #include(transform360.m4)
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
@@ -202,6 +203,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -215,6 +217,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib64"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -223,11 +226,23 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
+
+# Build librdkafka
+ARG LIBRDKAFKA_VER=0.11.6
+ARG FILE_NAME=v${LIBRDKAFKA_VER}
+ARG LIBRDKAFKA_REPO=https://github.com/edenhill/librdkafka/archive/${FILE_NAME}.tar.gz
+
+RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
+    cd librdkafka-${LIBRDKAFKA_VER} && \
+    ./configure --prefix=/usr --libdir=/usr/lib64 && \
+    make -j8 && \
+    make install DESTDIR=/home/build && \
+    make install;
 
 # Fetch FFmpeg source
 ARG FFMPEG_VER=n4.1
@@ -235,13 +250,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -249,7 +283,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl  --disable-xlib --disable-sdl2 --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl  --disable-xlib --disable-sdl2 --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine --enable-librdkafka  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/Xeon/centos-7.6/dldt+ffmpeg/Dockerfile.m4
+++ b/Xeon/centos-7.6/dldt+ffmpeg/Dockerfile.m4
@@ -18,6 +18,7 @@ include(svt-av1.m4)
 include(svt-vp9.m4)
 #include(transform360.m4)
 include(dldt-ie.m4)
+include(librdkafka.m4)
 include(ffmpeg.m4)
 include(cleanup.m4)dnl
 

--- a/Xeon/centos-7.6/dldt+gst/Dockerfile
+++ b/Xeon/centos-7.6/dldt+gst/Dockerfile
@@ -191,8 +191,9 @@ RUN git clone ${SVT_VP9_REPO} && \
     make install )
 
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
@@ -201,6 +202,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -214,6 +216,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib64"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -222,9 +225,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 

--- a/Xeon/centos-7.6/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/centos-7.6/ffmpeg+gst+dev/Dockerfile
@@ -192,8 +192,9 @@ RUN git clone ${SVT_VP9_REPO} && \
 
 #include(transform360.m4)
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
@@ -202,6 +203,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -215,6 +217,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib64"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -223,9 +226,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 
@@ -317,13 +320,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q libass-devel freetype-devel SDL2-devel libxcb-devel texinfo zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -331,7 +353,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/Xeon/centos-7.6/ffmpeg/Dockerfile
+++ b/Xeon/centos-7.6/ffmpeg/Dockerfile
@@ -197,13 +197,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \

--- a/Xeon/centos-7.6/ospray/Dockerfile
+++ b/Xeon/centos-7.6/ospray/Dockerfile
@@ -8,31 +8,31 @@ RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-c
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
-RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz; \
-    cd cmake-${CMAKE_VER}; \
-    ./bootstrap --prefix="/usr"; \
-    make -j8; \
+RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
+    cd cmake-${CMAKE_VER} && \
+    ./bootstrap --prefix="/usr" && \
+    make -j8 && \
     make install
 
 # Build NASM
 ARG NASM_VER=2.13.03
 ARG NASM_REPO=https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VER}/nasm-${NASM_VER}.tar.bz2
-RUN  wget ${NASM_REPO}; \
-     tar -xaf nasm*; \
-     cd nasm-${NASM_VER}; \
-     ./autogen.sh; \
-     ./configure --prefix="/usr" --libdir=/usr/lib64; \
-     make -j8; \
+RUN  wget ${NASM_REPO} && \
+     tar -xaf nasm* && \
+     cd nasm-${NASM_VER} && \
+     ./autogen.sh && \
+     ./configure --prefix="/usr" --libdir=/usr/lib64 && \
+     make -j8 && \
      make install
 
 # Build YASM
 ARG YASM_VER=1.3.0
 ARG YASM_REPO=https://www.tortall.net/projects/yasm/releases/yasm-${YASM_VER}.tar.gz
-RUN  wget -O - ${YASM_REPO} | tar xz; \
-     cd yasm-${YASM_VER}; \
-     sed -i "s/) ytasm.*/)/" Makefile.in; \
-     ./configure --prefix="/usr" --libdir=/usr/lib64; \
-     make -j8; \
+RUN  wget -O - ${YASM_REPO} | tar xz && \
+     cd yasm-${YASM_VER} && \
+     sed -i "s/) ytasm.*/)/" Makefile.in && \
+     ./configure --prefix="/usr" --libdir=/usr/lib64 && \
+     make -j8 && \
      make install
 
 #build ISPC

--- a/Xeon/ubuntu-16.04/dldt+ffmpeg/Dockerfile
+++ b/Xeon/ubuntu-16.04/dldt+ffmpeg/Dockerfile
@@ -187,8 +187,9 @@ RUN git clone ${SVT_VP9_REPO} && \
 
 #include(transform360.m4)
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
@@ -196,6 +197,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -209,6 +211,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib/x86_64-linux-gnu"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -217,11 +220,23 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
+
+# Build librdkafka
+ARG LIBRDKAFKA_VER=0.11.6
+ARG FILE_NAME=v${LIBRDKAFKA_VER}
+ARG LIBRDKAFKA_REPO=https://github.com/edenhill/librdkafka/archive/${FILE_NAME}.tar.gz
+
+RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
+    cd librdkafka-${LIBRDKAFKA_VER} && \
+    ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu && \
+    make -j8 && \
+    make install DESTDIR=/home/build && \
+    make install;
 
 # Fetch FFmpeg source
 ARG FFMPEG_VER=n4.1
@@ -229,13 +244,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends zlib1g-dev libssl-dev
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -243,7 +277,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl  --disable-xlib --disable-sdl2 --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl  --disable-xlib --disable-sdl2 --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine --enable-librdkafka  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/Xeon/ubuntu-16.04/dldt+ffmpeg/Dockerfile.m4
+++ b/Xeon/ubuntu-16.04/dldt+ffmpeg/Dockerfile.m4
@@ -18,6 +18,7 @@ include(svt-av1.m4)
 include(svt-vp9.m4)
 #include(transform360.m4)
 include(dldt-ie.m4)
+include(librdkafka.m4)
 include(ffmpeg.m4)
 include(cleanup.m4)dnl
 

--- a/Xeon/ubuntu-16.04/dldt+gst/Dockerfile
+++ b/Xeon/ubuntu-16.04/dldt+gst/Dockerfile
@@ -186,8 +186,9 @@ RUN git clone ${SVT_VP9_REPO} && \
     make install 
 
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
@@ -195,6 +196,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -208,6 +210,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib/x86_64-linux-gnu"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -216,9 +219,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 

--- a/Xeon/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
@@ -187,8 +187,9 @@ RUN git clone ${SVT_VP9_REPO} && \
 
 #include(transform360.m4)
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
@@ -196,6 +197,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -209,6 +211,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib/x86_64-linux-gnu"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -217,9 +220,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 
@@ -300,13 +303,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends libass-dev libfreetype6-dev libsdl2-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev texinfo zlib1g-dev libssl-dev
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -314,7 +336,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/Xeon/ubuntu-16.04/ffmpeg/Dockerfile
+++ b/Xeon/ubuntu-16.04/ffmpeg/Dockerfile
@@ -192,13 +192,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends zlib1g-dev libssl-dev
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \

--- a/Xeon/ubuntu-16.04/ospray/Dockerfile
+++ b/Xeon/ubuntu-16.04/ospray/Dockerfile
@@ -8,31 +8,31 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
-RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz; \
-    cd cmake-${CMAKE_VER}; \
-    ./bootstrap --prefix="/usr"; \
-    make -j8; \
+RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
+    cd cmake-${CMAKE_VER} && \
+    ./bootstrap --prefix="/usr" && \
+    make -j8 && \
     make install
 
 # Build NASM
 ARG NASM_VER=2.13.03
 ARG NASM_REPO=https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VER}/nasm-${NASM_VER}.tar.bz2
-RUN  wget ${NASM_REPO}; \
-     tar -xaf nasm*; \
-     cd nasm-${NASM_VER}; \
-     ./autogen.sh; \
-     ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu; \
-     make -j8; \
+RUN  wget ${NASM_REPO} && \
+     tar -xaf nasm* && \
+     cd nasm-${NASM_VER} && \
+     ./autogen.sh && \
+     ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu && \
+     make -j8 && \
      make install
 
 # Build YASM
 ARG YASM_VER=1.3.0
 ARG YASM_REPO=https://www.tortall.net/projects/yasm/releases/yasm-${YASM_VER}.tar.gz
-RUN  wget -O - ${YASM_REPO} | tar xz; \
-     cd yasm-${YASM_VER}; \
-     sed -i "s/) ytasm.*/)/" Makefile.in; \
-     ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu; \
-     make -j8; \
+RUN  wget -O - ${YASM_REPO} | tar xz && \
+     cd yasm-${YASM_VER} && \
+     sed -i "s/) ytasm.*/)/" Makefile.in && \
+     ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu && \
+     make -j8 && \
      make install
 
 #build ISPC

--- a/Xeon/ubuntu-18.04/dldt+ffmpeg/Dockerfile
+++ b/Xeon/ubuntu-18.04/dldt+ffmpeg/Dockerfile
@@ -187,8 +187,9 @@ RUN git clone ${SVT_VP9_REPO} && \
 
 #include(transform360.m4)
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
@@ -196,6 +197,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -209,6 +211,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib/x86_64-linux-gnu"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -217,11 +220,23 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
+
+# Build librdkafka
+ARG LIBRDKAFKA_VER=0.11.6
+ARG FILE_NAME=v${LIBRDKAFKA_VER}
+ARG LIBRDKAFKA_REPO=https://github.com/edenhill/librdkafka/archive/${FILE_NAME}.tar.gz
+
+RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
+    cd librdkafka-${LIBRDKAFKA_VER} && \
+    ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu && \
+    make -j8 && \
+    make install DESTDIR=/home/build && \
+    make install;
 
 # Fetch FFmpeg source
 ARG FFMPEG_VER=n4.1
@@ -229,13 +244,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends zlib1g-dev libssl-dev
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -243,7 +277,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl  --disable-xlib --disable-sdl2 --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl  --disable-xlib --disable-sdl2 --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine --enable-librdkafka  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/Xeon/ubuntu-18.04/dldt+ffmpeg/Dockerfile.m4
+++ b/Xeon/ubuntu-18.04/dldt+ffmpeg/Dockerfile.m4
@@ -18,6 +18,7 @@ include(svt-av1.m4)
 include(svt-vp9.m4)
 #include(transform360.m4)
 include(dldt-ie.m4)
+include(librdkafka.m4)
 include(ffmpeg.m4)
 include(cleanup.m4)dnl
 

--- a/Xeon/ubuntu-18.04/dldt+gst/Dockerfile
+++ b/Xeon/ubuntu-18.04/dldt+gst/Dockerfile
@@ -186,8 +186,9 @@ RUN git clone ${SVT_VP9_REPO} && \
     make install 
 
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
@@ -195,6 +196,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -208,6 +210,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib/x86_64-linux-gnu"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -216,9 +219,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 

--- a/Xeon/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
@@ -187,8 +187,9 @@ RUN git clone ${SVT_VP9_REPO} && \
 
 #include(transform360.m4)
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
@@ -196,6 +197,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -209,6 +211,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib/x86_64-linux-gnu"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -217,9 +220,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 
@@ -301,13 +304,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends libass-dev libfreetype6-dev libsdl2-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev texinfo zlib1g-dev libssl-dev
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -315,7 +337,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --disable-vaapi --disable-hwaccels  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/Xeon/ubuntu-18.04/ffmpeg/Dockerfile
+++ b/Xeon/ubuntu-18.04/ffmpeg/Dockerfile
@@ -192,13 +192,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends zlib1g-dev libssl-dev
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \

--- a/Xeon/ubuntu-18.04/ospray/Dockerfile
+++ b/Xeon/ubuntu-18.04/ospray/Dockerfile
@@ -8,31 +8,31 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
-RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz; \
-    cd cmake-${CMAKE_VER}; \
-    ./bootstrap --prefix="/usr"; \
-    make -j8; \
+RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
+    cd cmake-${CMAKE_VER} && \
+    ./bootstrap --prefix="/usr" && \
+    make -j8 && \
     make install
 
 # Build NASM
 ARG NASM_VER=2.13.03
 ARG NASM_REPO=https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VER}/nasm-${NASM_VER}.tar.bz2
-RUN  wget ${NASM_REPO}; \
-     tar -xaf nasm*; \
-     cd nasm-${NASM_VER}; \
-     ./autogen.sh; \
-     ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu; \
-     make -j8; \
+RUN  wget ${NASM_REPO} && \
+     tar -xaf nasm* && \
+     cd nasm-${NASM_VER} && \
+     ./autogen.sh && \
+     ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu && \
+     make -j8 && \
      make install
 
 # Build YASM
 ARG YASM_VER=1.3.0
 ARG YASM_REPO=https://www.tortall.net/projects/yasm/releases/yasm-${YASM_VER}.tar.gz
-RUN  wget -O - ${YASM_REPO} | tar xz; \
-     cd yasm-${YASM_VER}; \
-     sed -i "s/) ytasm.*/)/" Makefile.in; \
-     ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu; \
-     make -j8; \
+RUN  wget -O - ${YASM_REPO} | tar xz && \
+     cd yasm-${YASM_VER} && \
+     sed -i "s/) ytasm.*/)/" Makefile.in && \
+     ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu && \
+     make -j8 && \
      make install
 
 #build ISPC

--- a/XeonE3/centos-7.4/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/centos-7.4/ffmpeg+gst+dev/Dockerfile
@@ -242,8 +242,9 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK && \
     make install;
 
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
@@ -252,6 +253,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -265,6 +267,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib64"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -273,9 +276,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 
@@ -392,13 +395,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q libass-devel freetype-devel SDL2-devel libxcb-devel libvdpau-devel texinfo zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -406,7 +428,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/XeonE3/centos-7.4/ffmpeg/Dockerfile
+++ b/XeonE3/centos-7.4/ffmpeg/Dockerfile
@@ -249,13 +249,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q SDL2-devel libxcb-devel libvdpau-devel zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \

--- a/XeonE3/centos-7.5/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/centos-7.5/ffmpeg+gst+dev/Dockerfile
@@ -242,8 +242,9 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK && \
     make install;
 
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
@@ -252,6 +253,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -265,6 +267,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib64"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -273,9 +276,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 
@@ -392,13 +395,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q libass-devel freetype-devel SDL2-devel libxcb-devel libvdpau-devel texinfo zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -406,7 +428,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/XeonE3/centos-7.5/ffmpeg/Dockerfile
+++ b/XeonE3/centos-7.5/ffmpeg/Dockerfile
@@ -249,13 +249,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q SDL2-devel libxcb-devel libvdpau-devel zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \

--- a/XeonE3/centos-7.6/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/centos-7.6/ffmpeg+gst+dev/Dockerfile
@@ -242,8 +242,9 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK && \
     make install;
 
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
@@ -252,6 +253,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -265,6 +267,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib64"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -273,9 +276,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 
@@ -392,13 +395,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q libass-devel freetype-devel SDL2-devel libxcb-devel libvdpau-devel texinfo zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -406,7 +428,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib64 --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/XeonE3/centos-7.6/ffmpeg/Dockerfile
+++ b/XeonE3/centos-7.6/ffmpeg/Dockerfile
@@ -249,13 +249,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN yum install -y -q SDL2-devel libxcb-devel libvdpau-devel zlib-devel openssl-devel
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \

--- a/XeonE3/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
@@ -236,8 +236,9 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK && \
     make install;
 
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
@@ -245,6 +246,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -258,6 +260,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib/x86_64-linux-gnu"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -266,9 +269,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 
@@ -363,13 +366,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends libass-dev libfreetype6-dev libvdpau-dev libsdl2-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev texinfo zlib1g-dev libssl-dev
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -377,7 +399,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/XeonE3/ubuntu-16.04/ffmpeg/Dockerfile
+++ b/XeonE3/ubuntu-16.04/ffmpeg/Dockerfile
@@ -243,13 +243,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends libvdpau-dev libsdl2-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev zlib1g-dev libssl-dev
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \

--- a/XeonE3/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
@@ -236,8 +236,9 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK && \
     make install;
 
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
@@ -245,6 +246,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -258,6 +260,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/lib/x86_64-linux-gnu"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -266,9 +269,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
 
@@ -364,13 +367,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends libass-dev libfreetype6-dev libvdpau-dev libsdl2-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev texinfo zlib1g-dev libssl-dev
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \
@@ -378,7 +400,7 @@ RUN cd /home/FFmpeg && \
 
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc  && \
+    ./configure --prefix="/usr" --libdir=/usr/lib/x86_64-linux-gnu --extra-libs="-lpthread -lm" --enable-shared --enable-gpl --enable-libass --enable-libfreetype  --enable-openssl --enable-nonfree --enable-libdrm --enable-libmfx  --enable-libfdk-aac --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvthevc --enable-libinference_engine  && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/XeonE3/ubuntu-18.04/ffmpeg/Dockerfile
+++ b/XeonE3/ubuntu-18.04/ffmpeg/Dockerfile
@@ -243,13 +243,32 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends libvdpau-dev libsdl2-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev zlib1g-dev libssl-dev
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 # Patch FFmpeg source for SVT-HEVC
 RUN cd /home/FFmpeg && \

--- a/template/dldt-ie.m4
+++ b/template/dldt-ie.m4
@@ -1,6 +1,7 @@
 # Build DLDT-Inference Engine
-ARG DLDT_VER=2018_R4
+ARG DLDT_VER=2018_R5
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+ARG DLDT_C_API_REPO=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/thirdparty/0001-Add-inference-engine-C-API.patch
 
 ifelse(index(DOCKER_IMAGE,centos),-1,,dnl
 RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
@@ -11,6 +12,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
     git submodule init && \
     git submodule update --recursive && \
     cd inference-engine && \
+    wget -O - ${DLDT_C_API_REPO} | patch -p2 && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=ifelse(index(BUILD_LINKAGE,static),-1,ON,OFF) -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/ifelse(index(DOCKER_IMAGE,ubuntu),-1,lib64,lib/x86_64-linux-gnu) -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ifelse(index(DOCKER_IMAGE,xeon-),-1,ON,OFF) -DENABLE_SAMPLES_CORE=OFF  ..; \
@@ -24,6 +26,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         cp -r ../include/* $p/include/dldt; \
         libdir="$p/ifelse(index(DOCKER_IMAGE,ubuntu),-1,lib64,lib/x86_64-linux-gnu)"; \
         cp -r ../bin/intel64/Release/lib/* "$libdir"; \
+        cp -r ../temp/omp/lib/* "$libdir"; \
         mkdir -p "$libdir/pkgconfig"; \
         pc="$libdir/pkgconfig/dldt.pc"; \
         echo "prefix=/usr" > "$pc"; \
@@ -32,8 +35,9 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
         echo "" >> "$pc"; \
         echo "Name: DLDT" >> "$pc"; \
         echo "Description: Intel Deep Learning Deployment Toolkit" >> "$pc"; \
-        echo "Version: 4.0" >> "$pc"; \
+        echo "Version: 5.0" >> "$pc"; \
         echo "" >> "$pc"; \
-        echo "Libs: -L\${libdir} -linference_engine" >> "$pc"; \
+        echo "Libs: -L\${libdir} -linference_engine -linference_engine_c_wrapper" >> "$pc"; \
         echo "Cflags: -I\${includedir}" >> "$pc"; \
     done;
+define(`FFMPEG_CONFIG_DLDT_IE',--enable-libinference_engine )dnl

--- a/template/ffmpeg.m4
+++ b/template/ffmpeg.m4
@@ -4,6 +4,15 @@ ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VER}.tar.gz
 ARG FFMPEG_FLV_PATCH_REPO=https://raw.githubusercontent.com/VCDP/CDN/master/The-RTMP-protocol-extensions-for-H.265-HEVC.patch
 ARG FFMPEG_1TN_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11625/raw
 ARG FFMPEG_THREAD_PATCH_REPO=https://patchwork.ffmpeg.org/patch/11035/raw
+ARG FFMPEG_MA_PATCH_REPO_01=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0001-Intel-inference-engine-detection-filter.patch
+ARG FFMPEG_MA_PATCH_REPO_02=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0002-New-filter-to-do-inference-classify.patch
+ARG FFMPEG_MA_PATCH_REPO_03=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0003-iemetadata-convertor-muxer.patch
+ARG FFMPEG_MA_PATCH_REPO_04=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0004-Kafka-protocol-producer.patch
+ARG FFMPEG_MA_PATCH_REPO_05=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0005-Support-object-detection-and-featured-face-identific.patch
+ARG FFMPEG_MA_PATCH_REPO_06=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0006-Send-metadata-in-a-packet-and-refine-the-json-format.patch
+ARG FFMPEG_MA_PATCH_REPO_07=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0007-Refine-features-of-IE-filters.patch
+ARG FFMPEG_MA_PATCH_REPO_08=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0008-fixed-extra-comma-in-iemetadata.patch
+ARG FFMPEG_MA_PATCH_REPO_09=https://raw.githubusercontent.com/VCDP/FFmpeg-patch/master/media-analytics/0009-add-source-as-option-source-url-calculate-nano-times.patch
 define(`FFMPEG_SUBTITLE',ifelse(index(DOCKER_IMAGE,-dev),-1,OFF,ON))dnl
 define(`FFMPEG_X11',ifelse(index(DOCKER_IMAGE,-dev),-1,ifelse(index(DOCKER_IMAGE,xeon-),-1,ON,OFF),ON))dnl
 
@@ -13,16 +22,26 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-
 ifelse(index(DOCKER_IMAGE,centos),-1,,
 RUN yum install -y -q ifelse(FFMPEG_SUBTITLE,ON,libass-devel freetype-devel )ifelse(FFMPEG_X11,ON,SDL2-devel libxcb-devel )ifelse(index(DOCKER_IMAGE,xeon-),-1,libvdpau-devel )ifelse(index(DOCKER_IMAGE,-dev),-1,,texinfo )zlib-devel openssl-devel
 )dnl
+
 RUN wget -O - ${FFMPEG_REPO} | tar xz && mv FFmpeg-${FFMPEG_VER} FFmpeg && \
     cd FFmpeg && \
     wget -O - ${FFMPEG_FLV_PATCH_REPO} | patch -p1 && \
     wget -O - ${FFMPEG_1TN_PATCH_REPO} | patch -p1 && \
-    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1;
+    wget -O - ${FFMPEG_THREAD_PATCH_REPO} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_01} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_02} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_03} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_04} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_05} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_06} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_07} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_08} | patch -p1 && \
+    wget -O - ${FFMPEG_MA_PATCH_REPO_09} | patch -p1;
 
 defn(`FFMPEG_SOURCE_SVT_HEVC',`FFMPEG_SOURCE_TRANSFORM360')dnl
 # Compile FFmpeg
 RUN cd /home/FFmpeg && \
-    ./configure --prefix="/usr" --libdir=ifelse(index(DOCKER_IMAGE,ubuntu),-1,/usr/lib64,/usr/lib/x86_64-linux-gnu) --extra-libs="-lpthread -lm" --enable-defn(`BUILD_LINKAGE') --enable-gpl ifelse(FFMPEG_SUBTITLE,ON,--enable-libass --enable-libfreetype) ifelse(FFMPEG_X11,OFF,--disable-xlib --disable-sdl2) --enable-openssl --enable-nonfree ifelse(index(DOCKER_IMAGE,xeon-),-1,--enable-libdrm --enable-libmfx,--disable-vaapi --disable-hwaccels) ifelse(index(DOCKER_IMAGE,-dev),-1,--disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages) defn(`FFMPEG_CONFIG_FDKAAC',`FFMPEG_CONFIG_MP3LAME',`FFMPEG_CONFIG_OPUS',`FFMPEG_CONFIG_VORBIS',`FFMPEG_CONFIG_VPX',`FFMPEG_CONFIG_X264',`FFMPEG_CONFIG_X265',`FFMPEG_CONFIG_AOM',`FFMPEG_CONFIG_SVT_HEVC',`FFMPEG_CONFIG_TRANSFORM360') && \
+    ./configure --prefix="/usr" --libdir=ifelse(index(DOCKER_IMAGE,ubuntu),-1,/usr/lib64,/usr/lib/x86_64-linux-gnu) --extra-libs="-lpthread -lm" --enable-defn(`BUILD_LINKAGE') --enable-gpl ifelse(FFMPEG_SUBTITLE,ON,--enable-libass --enable-libfreetype) ifelse(FFMPEG_X11,OFF,--disable-xlib --disable-sdl2) --enable-openssl --enable-nonfree ifelse(index(DOCKER_IMAGE,xeon-),-1,--enable-libdrm --enable-libmfx,--disable-vaapi --disable-hwaccels) ifelse(index(DOCKER_IMAGE,-dev),-1,--disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages) defn(`FFMPEG_CONFIG_FDKAAC',`FFMPEG_CONFIG_MP3LAME',`FFMPEG_CONFIG_OPUS',`FFMPEG_CONFIG_VORBIS',`FFMPEG_CONFIG_VPX',`FFMPEG_CONFIG_X264',`FFMPEG_CONFIG_X265',`FFMPEG_CONFIG_AOM',`FFMPEG_CONFIG_SVT_HEVC',`FFMPEG_CONFIG_TRANSFORM360',`FFMPEG_CONFIG_DLDT_IE',`FFMPEG_CONFIG_LIBRDKAFKA') && \
     make -j8 && \
     make install DESTDIR="/home/build"
 

--- a/template/librdkafka.m4
+++ b/template/librdkafka.m4
@@ -1,0 +1,12 @@
+# Build librdkafka
+ARG LIBRDKAFKA_VER=0.11.6
+ARG FILE_NAME=v${LIBRDKAFKA_VER}
+ARG LIBRDKAFKA_REPO=https://github.com/edenhill/librdkafka/archive/${FILE_NAME}.tar.gz
+
+RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
+    cd librdkafka-${LIBRDKAFKA_VER} && \
+    ./configure --prefix=/usr --libdir=/usr/ifelse(index(DOCKER_IMAGE,ubuntu),-1,lib64,lib/x86_64-linux-gnu) && \
+    make -j8 && \
+    make install DESTDIR=/home/build && \
+    make install;
+define(`FFMPEG_CONFIG_LIBRDKAFKA',--enable-librdkafka )dnl


### PR DESCRIPTION
Patches are cherry-picked from gitlab Dockerfile repo branch ffmpeg-filters-for-dldt.
To enable using DLDT IE as a backend to develope ffmpeg filters for video/image inference.

Main changes:
* Updated DLDT to 2018R5
* Add patches and new configurations into ffmpeg template
* Add template librdkafka.m4 and use it to produce kafka messages