### PR TITLE
Fix DLDT compiling failure on CentOS

### DIFF
--- a/VCA2/centos-7.4/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/centos-7.4/ffmpeg+gst+dev/Dockerfile
@@ -244,6 +244,11 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -251,7 +256,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/VCA2/centos-7.4/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/centos-7.4/ffmpeg+gst+dev/Dockerfile
@@ -245,23 +245,21 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/VCA2/centos-7.5/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/centos-7.5/ffmpeg+gst+dev/Dockerfile
@@ -244,6 +244,11 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -251,7 +256,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/VCA2/centos-7.5/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/centos-7.5/ffmpeg+gst+dev/Dockerfile
@@ -245,23 +245,21 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/VCA2/centos-7.6/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/centos-7.6/ffmpeg+gst+dev/Dockerfile
@@ -244,6 +244,11 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -251,7 +256,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/VCA2/centos-7.6/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/centos-7.6/ffmpeg+gst+dev/Dockerfile
@@ -245,23 +245,21 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/VCA2/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
@@ -238,6 +238,8 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -245,7 +247,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/VCA2/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
@@ -240,19 +240,19 @@ ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/VCA2/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
@@ -238,6 +238,8 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -245,7 +247,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/VCA2/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
@@ -240,19 +240,19 @@ ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/Xeon/centos-7.4/dldt+ffmpeg/Dockerfile
+++ b/Xeon/centos-7.4/dldt+ffmpeg/Dockerfile
@@ -194,6 +194,11 @@ RUN git clone ${SVT_VP9_REPO}; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -201,7 +206,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/Xeon/centos-7.4/dldt+ffmpeg/Dockerfile
+++ b/Xeon/centos-7.4/dldt+ffmpeg/Dockerfile
@@ -195,23 +195,21 @@ RUN git clone ${SVT_VP9_REPO}; \
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/Xeon/centos-7.4/dldt+gst/Dockerfile
+++ b/Xeon/centos-7.4/dldt+gst/Dockerfile
@@ -194,23 +194,21 @@ RUN git clone ${SVT_VP9_REPO}; \
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/Xeon/centos-7.4/dldt+gst/Dockerfile
+++ b/Xeon/centos-7.4/dldt+gst/Dockerfile
@@ -193,6 +193,11 @@ RUN git clone ${SVT_VP9_REPO}; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -200,7 +205,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/Xeon/centos-7.4/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/centos-7.4/ffmpeg+gst+dev/Dockerfile
@@ -194,6 +194,11 @@ RUN git clone ${SVT_VP9_REPO}; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -201,7 +206,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/Xeon/centos-7.4/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/centos-7.4/ffmpeg+gst+dev/Dockerfile
@@ -195,23 +195,21 @@ RUN git clone ${SVT_VP9_REPO}; \
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/Xeon/centos-7.5/dldt+ffmpeg/Dockerfile
+++ b/Xeon/centos-7.5/dldt+ffmpeg/Dockerfile
@@ -194,6 +194,11 @@ RUN git clone ${SVT_VP9_REPO}; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -201,7 +206,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/Xeon/centos-7.5/dldt+ffmpeg/Dockerfile
+++ b/Xeon/centos-7.5/dldt+ffmpeg/Dockerfile
@@ -195,23 +195,21 @@ RUN git clone ${SVT_VP9_REPO}; \
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/Xeon/centos-7.5/dldt+gst/Dockerfile
+++ b/Xeon/centos-7.5/dldt+gst/Dockerfile
@@ -194,23 +194,21 @@ RUN git clone ${SVT_VP9_REPO}; \
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/Xeon/centos-7.5/dldt+gst/Dockerfile
+++ b/Xeon/centos-7.5/dldt+gst/Dockerfile
@@ -193,6 +193,11 @@ RUN git clone ${SVT_VP9_REPO}; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -200,7 +205,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/Xeon/centos-7.5/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/centos-7.5/ffmpeg+gst+dev/Dockerfile
@@ -194,6 +194,11 @@ RUN git clone ${SVT_VP9_REPO}; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -201,7 +206,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/Xeon/centos-7.5/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/centos-7.5/ffmpeg+gst+dev/Dockerfile
@@ -195,23 +195,21 @@ RUN git clone ${SVT_VP9_REPO}; \
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/Xeon/centos-7.6/dldt+ffmpeg/Dockerfile
+++ b/Xeon/centos-7.6/dldt+ffmpeg/Dockerfile
@@ -194,6 +194,11 @@ RUN git clone ${SVT_VP9_REPO}; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -201,7 +206,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/Xeon/centos-7.6/dldt+ffmpeg/Dockerfile
+++ b/Xeon/centos-7.6/dldt+ffmpeg/Dockerfile
@@ -195,23 +195,21 @@ RUN git clone ${SVT_VP9_REPO}; \
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/Xeon/centos-7.6/dldt+gst/Dockerfile
+++ b/Xeon/centos-7.6/dldt+gst/Dockerfile
@@ -194,23 +194,21 @@ RUN git clone ${SVT_VP9_REPO}; \
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/Xeon/centos-7.6/dldt+gst/Dockerfile
+++ b/Xeon/centos-7.6/dldt+gst/Dockerfile
@@ -193,6 +193,11 @@ RUN git clone ${SVT_VP9_REPO}; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -200,7 +205,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/Xeon/centos-7.6/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/centos-7.6/ffmpeg+gst+dev/Dockerfile
@@ -194,6 +194,11 @@ RUN git clone ${SVT_VP9_REPO}; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -201,7 +206,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/Xeon/centos-7.6/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/centos-7.6/ffmpeg+gst+dev/Dockerfile
@@ -195,23 +195,21 @@ RUN git clone ${SVT_VP9_REPO}; \
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/Xeon/ubuntu-16.04/dldt+ffmpeg/Dockerfile
+++ b/Xeon/ubuntu-16.04/dldt+ffmpeg/Dockerfile
@@ -189,6 +189,8 @@ RUN git clone ${SVT_VP9_REPO}; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -196,7 +198,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/Xeon/ubuntu-16.04/dldt+ffmpeg/Dockerfile
+++ b/Xeon/ubuntu-16.04/dldt+ffmpeg/Dockerfile
@@ -191,19 +191,19 @@ ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/Xeon/ubuntu-16.04/dldt+gst/Dockerfile
+++ b/Xeon/ubuntu-16.04/dldt+gst/Dockerfile
@@ -190,19 +190,19 @@ ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/Xeon/ubuntu-16.04/dldt+gst/Dockerfile
+++ b/Xeon/ubuntu-16.04/dldt+gst/Dockerfile
@@ -188,6 +188,8 @@ RUN git clone ${SVT_VP9_REPO}; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -195,7 +197,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/Xeon/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
@@ -189,6 +189,8 @@ RUN git clone ${SVT_VP9_REPO}; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -196,7 +198,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/Xeon/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
@@ -191,19 +191,19 @@ ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/Xeon/ubuntu-18.04/dldt+ffmpeg/Dockerfile
+++ b/Xeon/ubuntu-18.04/dldt+ffmpeg/Dockerfile
@@ -189,6 +189,8 @@ RUN git clone ${SVT_VP9_REPO}; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -196,7 +198,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/Xeon/ubuntu-18.04/dldt+ffmpeg/Dockerfile
+++ b/Xeon/ubuntu-18.04/dldt+ffmpeg/Dockerfile
@@ -191,19 +191,19 @@ ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/Xeon/ubuntu-18.04/dldt+gst/Dockerfile
+++ b/Xeon/ubuntu-18.04/dldt+gst/Dockerfile
@@ -190,19 +190,19 @@ ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/Xeon/ubuntu-18.04/dldt+gst/Dockerfile
+++ b/Xeon/ubuntu-18.04/dldt+gst/Dockerfile
@@ -188,6 +188,8 @@ RUN git clone ${SVT_VP9_REPO}; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -195,7 +197,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/Xeon/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
@@ -189,6 +189,8 @@ RUN git clone ${SVT_VP9_REPO}; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -196,7 +198,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/Xeon/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
@@ -191,19 +191,19 @@ ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=OFF -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/XeonE3/centos-7.4/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/centos-7.4/ffmpeg+gst+dev/Dockerfile
@@ -244,6 +244,11 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -251,7 +256,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/XeonE3/centos-7.4/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/centos-7.4/ffmpeg+gst+dev/Dockerfile
@@ -245,23 +245,21 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/XeonE3/centos-7.5/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/centos-7.5/ffmpeg+gst+dev/Dockerfile
@@ -244,6 +244,11 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -251,7 +256,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/XeonE3/centos-7.5/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/centos-7.5/ffmpeg+gst+dev/Dockerfile
@@ -245,23 +245,21 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/XeonE3/centos-7.6/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/centos-7.6/ffmpeg+gst+dev/Dockerfile
@@ -244,6 +244,11 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -251,7 +256,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/XeonE3/centos-7.6/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/centos-7.6/ffmpeg+gst+dev/Dockerfile
@@ -245,23 +245,21 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib64 -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/XeonE3/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
@@ -238,6 +238,8 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -245,7 +247,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/XeonE3/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
@@ -240,19 +240,19 @@ ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/XeonE3/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
@@ -238,6 +238,8 @@ RUN wget -O - ${MSDK_REPO} | tar xz && mv MediaSDK-${MSDK_VER} MediaSDK; \
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -245,7 +247,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \

--- a/XeonE3/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
@@ -240,19 +240,19 @@ ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/lib/x86_64-linux-gnu -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ON -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/template/dldt-ie.m4
+++ b/template/dldt-ie.m4
@@ -3,24 +3,22 @@ ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
 
 ifelse(index(DOCKER_IMAGE,centos),-1,,dnl
-RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
-boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
-glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+RUN yum install -y -q boost-devel glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc libusbx-devel openblas-devel;
 )dnl
 
-RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
-    cd dldt; \
-    git submodule init; \
-    git submodule update --recursive; \
-    cd inference-engine; \
-    mkdir build; \
-    cd build; \
+RUN git clone -b ${DLDT_VER} ${DLDT_REPO} && \
+    cd dldt && \
+    git submodule init && \
+    git submodule update --recursive && \
+    cd inference-engine && \
+    mkdir build && \
+    cd build && \
     cmake -DBUILD_SHARED_LIBS=ifelse(index(BUILD_LINKAGE,static),-1,ON,OFF) -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/ifelse(index(DOCKER_IMAGE,ubuntu),-1,lib64,lib/x86_64-linux-gnu) -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ifelse(index(DOCKER_IMAGE,xeon-),-1,ON,OFF) -DENABLE_SAMPLES_CORE=OFF  ..; \
-    make -j16; \
-    rm -rf ../bin/intel64/Release/lib/libgtest*; \
-    rm -rf ../bin/intel64/Release/lib/libgmock*; \
-    rm -rf ../bin/intel64/Release/lib/libmock*; \
-    rm -rf ../bin/intel64/Release/lib/libtest*; \
+    make -j16 && \
+    rm -rf ../bin/intel64/Release/lib/libgtest* && \
+    rm -rf ../bin/intel64/Release/lib/libgmock* && \
+    rm -rf ../bin/intel64/Release/lib/libmock* && \
+    rm -rf ../bin/intel64/Release/lib/libtest* && \
     for p in /usr /home/build/usr; do \
         mkdir -p $p/include/dldt; \
         cp -r ../include/* $p/include/dldt; \

--- a/template/dldt-ie.m4
+++ b/template/dldt-ie.m4
@@ -1,6 +1,13 @@
 # Build DLDT-Inference Engine
 ARG DLDT_VER=2018_R4
 ARG DLDT_REPO=https://github.com/opencv/dldt.git
+
+ifelse(index(DOCKER_IMAGE,centos),-1,,dnl
+RUN yum install -y -q centos-release-scl tar xz p7zip unzip yum-plugin-ovl which libssl-dev ca-certificates \
+boost-devel libtool glibc-static glibc-devel libstdc++-static libstdc++-devel libstdc++ libgcc glibc-static.i686 \
+glibc-devel.i686 libstdc++-static.i686 \ libstdc++.i686 libgcc.i686 libusbx-devel openblas-devel libusbx-devel;
+)dnl
+
 RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd dldt; \
     git submodule init; \
@@ -8,7 +15,7 @@ RUN git clone -b ${DLDT_VER} ${DLDT_REPO}; \
     cd inference-engine; \
     mkdir build; \
     cd build; \
-    cmake -DBUILD_SHARED_LIBS=ifelse(index(BUILD_LINKAGE,static),-1,ON,OFF) -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/ifelse(index(DOCKER_IMAGE,ubuntu),-1,lib64,lib/x86_64-linux-gnu) -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ifelse(index(DOCKER_IMAGE,xeon-),-1,ON,OFF) -DENABLE_SAMPLE_CORE=OFF  ..; \
+    cmake -DBUILD_SHARED_LIBS=ifelse(index(BUILD_LINKAGE,static),-1,ON,OFF) -DCMAKE_INSTALL_PREFIX=/usr -DLIB_INSTALL_PATH=/usr/ifelse(index(DOCKER_IMAGE,ubuntu),-1,lib64,lib/x86_64-linux-gnu) -DENABLE_MKL_DNN=ON -DENABLE_CLDNN=ifelse(index(DOCKER_IMAGE,xeon-),-1,ON,OFF) -DENABLE_SAMPLES_CORE=OFF  ..; \
     make -j16; \
     rm -rf ../bin/intel64/Release/lib/libgtest*; \
     rm -rf ../bin/intel64/Release/lib/libgmock*; \


### PR DESCRIPTION
* Add dependent packages for building dldt on CentOS
* Fix one typo

Current dldt build is failed on CentOS due to miss some dependencies but not impact the whole image as no other modules are using it.
This patch add those dependencies and can resolve CentOS build issue for [PR#10](https://github.com/OpenVisualCloud/Dockerfiles/pull/10)