### PR TITLE
updated to OpenCV v4.1.0 & fixed cmake build options

### DIFF
--- a/VCA2/centos-7.4/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/centos-7.4/ffmpeg+gst+dev/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/centos-7.4/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/centos-7.4/ffmpeg+gst+dev/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/VCA2/centos-7.4/ffmpeg/Dockerfile
+++ b/VCA2/centos-7.4/ffmpeg/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/centos-7.4/ffmpeg/Dockerfile
+++ b/VCA2/centos-7.4/ffmpeg/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/VCA2/centos-7.4/gst/Dockerfile
+++ b/VCA2/centos-7.4/gst/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/centos-7.4/gst/Dockerfile
+++ b/VCA2/centos-7.4/gst/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/VCA2/centos-7.4/nginx+rtmp/Dockerfile
+++ b/VCA2/centos-7.4/nginx+rtmp/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/centos-7.4/nginx+rtmp/Dockerfile
+++ b/VCA2/centos-7.4/nginx+rtmp/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/VCA2/centos-7.5/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/centos-7.5/ffmpeg+gst+dev/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/centos-7.5/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/centos-7.5/ffmpeg+gst+dev/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/VCA2/centos-7.5/ffmpeg/Dockerfile
+++ b/VCA2/centos-7.5/ffmpeg/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/centos-7.5/ffmpeg/Dockerfile
+++ b/VCA2/centos-7.5/ffmpeg/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/VCA2/centos-7.5/gst/Dockerfile
+++ b/VCA2/centos-7.5/gst/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/centos-7.5/gst/Dockerfile
+++ b/VCA2/centos-7.5/gst/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/VCA2/centos-7.5/nginx+rtmp/Dockerfile
+++ b/VCA2/centos-7.5/nginx+rtmp/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/centos-7.5/nginx+rtmp/Dockerfile
+++ b/VCA2/centos-7.5/nginx+rtmp/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/VCA2/centos-7.6/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/centos-7.6/ffmpeg+gst+dev/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/VCA2/centos-7.6/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/centos-7.6/ffmpeg+gst+dev/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/centos-7.6/ffmpeg/Dockerfile
+++ b/VCA2/centos-7.6/ffmpeg/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/VCA2/centos-7.6/ffmpeg/Dockerfile
+++ b/VCA2/centos-7.6/ffmpeg/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/centos-7.6/gst/Dockerfile
+++ b/VCA2/centos-7.6/gst/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/VCA2/centos-7.6/gst/Dockerfile
+++ b/VCA2/centos-7.6/gst/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/centos-7.6/nginx+rtmp/Dockerfile
+++ b/VCA2/centos-7.6/nginx+rtmp/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/VCA2/centos-7.6/nginx+rtmp/Dockerfile
+++ b/VCA2/centos-7.6/nginx+rtmp/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/ubuntu-16.04/ffmpeg/Dockerfile
+++ b/VCA2/ubuntu-16.04/ffmpeg/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/ubuntu-16.04/gst/Dockerfile
+++ b/VCA2/ubuntu-16.04/gst/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/ubuntu-16.04/nginx+rtmp/Dockerfile
+++ b/VCA2/ubuntu-16.04/nginx+rtmp/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
+++ b/VCA2/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/ubuntu-18.04/ffmpeg/Dockerfile
+++ b/VCA2/ubuntu-18.04/ffmpeg/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/ubuntu-18.04/gst/Dockerfile
+++ b/VCA2/ubuntu-18.04/gst/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/VCA2/ubuntu-18.04/nginx+rtmp/Dockerfile
+++ b/VCA2/ubuntu-18.04/nginx+rtmp/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.4/dldt+ffmpeg/Dockerfile
+++ b/Xeon/centos-7.4/dldt+ffmpeg/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.4/dldt+ffmpeg/Dockerfile
+++ b/Xeon/centos-7.4/dldt+ffmpeg/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.4/dldt+gst/Dockerfile
+++ b/Xeon/centos-7.4/dldt+gst/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -418,7 +418,7 @@ RUN cd SVT-AV1/gstreamer-plugin && \
     make install DESTDIR=/home/build && \
     make install
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 

--- a/Xeon/centos-7.4/dldt+gst/Dockerfile
+++ b/Xeon/centos-7.4/dldt+gst/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.4/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/centos-7.4/ffmpeg+gst+dev/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.4/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/centos-7.4/ffmpeg+gst+dev/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -456,7 +456,7 @@ RUN cd SVT-AV1/gstreamer-plugin && \
     make install DESTDIR=/home/build && \
     make install
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 

--- a/Xeon/centos-7.4/ffmpeg/Dockerfile
+++ b/Xeon/centos-7.4/ffmpeg/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.4/ffmpeg/Dockerfile
+++ b/Xeon/centos-7.4/ffmpeg/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.4/gst/Dockerfile
+++ b/Xeon/centos-7.4/gst/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.4/gst/Dockerfile
+++ b/Xeon/centos-7.4/gst/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.4/nginx+rtmp/Dockerfile
+++ b/Xeon/centos-7.4/nginx+rtmp/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.4/nginx+rtmp/Dockerfile
+++ b/Xeon/centos-7.4/nginx+rtmp/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.4/ospray+mpi+OpenImageIO/Dockerfile
+++ b/Xeon/centos-7.4/ospray+mpi+OpenImageIO/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.4/ospray+mpi+OpenImageIO/Dockerfile
+++ b/Xeon/centos-7.4/ospray+mpi+OpenImageIO/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.4/ospray/Dockerfile
+++ b/Xeon/centos-7.4/ospray/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.4/ospray/Dockerfile
+++ b/Xeon/centos-7.4/ospray/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.5/dldt+ffmpeg/Dockerfile
+++ b/Xeon/centos-7.5/dldt+ffmpeg/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.5/dldt+ffmpeg/Dockerfile
+++ b/Xeon/centos-7.5/dldt+ffmpeg/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.5/dldt+gst/Dockerfile
+++ b/Xeon/centos-7.5/dldt+gst/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -418,7 +418,7 @@ RUN cd SVT-AV1/gstreamer-plugin && \
     make install DESTDIR=/home/build && \
     make install
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 

--- a/Xeon/centos-7.5/dldt+gst/Dockerfile
+++ b/Xeon/centos-7.5/dldt+gst/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.5/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/centos-7.5/ffmpeg+gst+dev/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.5/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/centos-7.5/ffmpeg+gst+dev/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -456,7 +456,7 @@ RUN cd SVT-AV1/gstreamer-plugin && \
     make install DESTDIR=/home/build && \
     make install
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 

--- a/Xeon/centos-7.5/ffmpeg/Dockerfile
+++ b/Xeon/centos-7.5/ffmpeg/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.5/ffmpeg/Dockerfile
+++ b/Xeon/centos-7.5/ffmpeg/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.5/gst/Dockerfile
+++ b/Xeon/centos-7.5/gst/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.5/gst/Dockerfile
+++ b/Xeon/centos-7.5/gst/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.5/nginx+rtmp/Dockerfile
+++ b/Xeon/centos-7.5/nginx+rtmp/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.5/nginx+rtmp/Dockerfile
+++ b/Xeon/centos-7.5/nginx+rtmp/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.5/ospray+mpi+OpenImageIO/Dockerfile
+++ b/Xeon/centos-7.5/ospray+mpi+OpenImageIO/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.5/ospray+mpi+OpenImageIO/Dockerfile
+++ b/Xeon/centos-7.5/ospray+mpi+OpenImageIO/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.5/ospray/Dockerfile
+++ b/Xeon/centos-7.5/ospray/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.5/ospray/Dockerfile
+++ b/Xeon/centos-7.5/ospray/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.6/dldt+ffmpeg/Dockerfile
+++ b/Xeon/centos-7.6/dldt+ffmpeg/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.6/dldt+ffmpeg/Dockerfile
+++ b/Xeon/centos-7.6/dldt+ffmpeg/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.6/dldt+gst/Dockerfile
+++ b/Xeon/centos-7.6/dldt+gst/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -418,7 +418,7 @@ RUN cd SVT-AV1/gstreamer-plugin && \
     make install DESTDIR=/home/build && \
     make install
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 

--- a/Xeon/centos-7.6/dldt+gst/Dockerfile
+++ b/Xeon/centos-7.6/dldt+gst/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.6/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/centos-7.6/ffmpeg+gst+dev/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.6/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/centos-7.6/ffmpeg+gst+dev/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -456,7 +456,7 @@ RUN cd SVT-AV1/gstreamer-plugin && \
     make install DESTDIR=/home/build && \
     make install
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 

--- a/Xeon/centos-7.6/ffmpeg/Dockerfile
+++ b/Xeon/centos-7.6/ffmpeg/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.6/ffmpeg/Dockerfile
+++ b/Xeon/centos-7.6/ffmpeg/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.6/gst/Dockerfile
+++ b/Xeon/centos-7.6/gst/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.6/gst/Dockerfile
+++ b/Xeon/centos-7.6/gst/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.6/nginx+rtmp/Dockerfile
+++ b/Xeon/centos-7.6/nginx+rtmp/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.6/nginx+rtmp/Dockerfile
+++ b/Xeon/centos-7.6/nginx+rtmp/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.6/ospray+mpi+OpenImageIO/Dockerfile
+++ b/Xeon/centos-7.6/ospray+mpi+OpenImageIO/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.6/ospray+mpi+OpenImageIO/Dockerfile
+++ b/Xeon/centos-7.6/ospray+mpi+OpenImageIO/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/centos-7.6/ospray/Dockerfile
+++ b/Xeon/centos-7.6/ospray/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/Xeon/centos-7.6/ospray/Dockerfile
+++ b/Xeon/centos-7.6/ospray/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/ubuntu-16.04/dldt+ffmpeg/Dockerfile
+++ b/Xeon/ubuntu-16.04/dldt+ffmpeg/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/ubuntu-16.04/dldt+gst/Dockerfile
+++ b/Xeon/ubuntu-16.04/dldt+gst/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -408,7 +408,7 @@ RUN cd SVT-AV1/gstreamer-plugin && \
     make install DESTDIR=/home/build && \
     make install
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 RUN  DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev python-dev python-numpy

--- a/Xeon/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -438,7 +438,7 @@ RUN cd SVT-AV1/gstreamer-plugin && \
     make install DESTDIR=/home/build && \
     make install
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 RUN  DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev python-dev python-numpy

--- a/Xeon/ubuntu-16.04/ffmpeg/Dockerfile
+++ b/Xeon/ubuntu-16.04/ffmpeg/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/ubuntu-16.04/gst/Dockerfile
+++ b/Xeon/ubuntu-16.04/gst/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/ubuntu-16.04/nginx+rtmp/Dockerfile
+++ b/Xeon/ubuntu-16.04/nginx+rtmp/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/ubuntu-16.04/ospray+mpi+OpenImageIO/Dockerfile
+++ b/Xeon/ubuntu-16.04/ospray+mpi+OpenImageIO/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/ubuntu-16.04/ospray/Dockerfile
+++ b/Xeon/ubuntu-16.04/ospray/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/ubuntu-18.04/dldt+ffmpeg/Dockerfile
+++ b/Xeon/ubuntu-18.04/dldt+ffmpeg/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/ubuntu-18.04/dldt+gst/Dockerfile
+++ b/Xeon/ubuntu-18.04/dldt+gst/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -410,7 +410,7 @@ RUN cd SVT-AV1/gstreamer-plugin && \
     make install DESTDIR=/home/build && \
     make install
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 RUN  ln -sf /usr/share/zoneinfo/UTC /etc/localtime;

--- a/Xeon/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
+++ b/Xeon/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -440,7 +440,7 @@ RUN cd SVT-AV1/gstreamer-plugin && \
     make install DESTDIR=/home/build && \
     make install
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 RUN  ln -sf /usr/share/zoneinfo/UTC /etc/localtime;

--- a/Xeon/ubuntu-18.04/ffmpeg/Dockerfile
+++ b/Xeon/ubuntu-18.04/ffmpeg/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/ubuntu-18.04/gst/Dockerfile
+++ b/Xeon/ubuntu-18.04/gst/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/ubuntu-18.04/nginx+rtmp/Dockerfile
+++ b/Xeon/ubuntu-18.04/nginx+rtmp/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/ubuntu-18.04/ospray+mpi+OpenImageIO/Dockerfile
+++ b/Xeon/ubuntu-18.04/ospray+mpi+OpenImageIO/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/Xeon/ubuntu-18.04/ospray/Dockerfile
+++ b/Xeon/ubuntu-18.04/ospray/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/XeonE3/centos-7.4/dldt+gst/Dockerfile
+++ b/XeonE3/centos-7.4/dldt+gst/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -521,7 +521,7 @@ RUN  wget -O - ${GST_PLUGIN_VAAPI_REPO} | tar xJ && \
      make install
 
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 

--- a/XeonE3/centos-7.4/dldt+gst/Dockerfile
+++ b/XeonE3/centos-7.4/dldt+gst/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/XeonE3/centos-7.4/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/centos-7.4/ffmpeg+gst+dev/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -557,7 +557,7 @@ RUN  wget -O - ${GST_PLUGIN_VAAPI_REPO} | tar xJ && \
      make install
 
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 

--- a/XeonE3/centos-7.4/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/centos-7.4/ffmpeg+gst+dev/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/XeonE3/centos-7.4/ffmpeg/Dockerfile
+++ b/XeonE3/centos-7.4/ffmpeg/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/XeonE3/centos-7.4/ffmpeg/Dockerfile
+++ b/XeonE3/centos-7.4/ffmpeg/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/XeonE3/centos-7.4/gst/Dockerfile
+++ b/XeonE3/centos-7.4/gst/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/XeonE3/centos-7.4/gst/Dockerfile
+++ b/XeonE3/centos-7.4/gst/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/XeonE3/centos-7.4/nginx+rtmp/Dockerfile
+++ b/XeonE3/centos-7.4/nginx+rtmp/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/XeonE3/centos-7.4/nginx+rtmp/Dockerfile
+++ b/XeonE3/centos-7.4/nginx+rtmp/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.4.1708 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/XeonE3/centos-7.5/dldt+gst/Dockerfile
+++ b/XeonE3/centos-7.5/dldt+gst/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -521,7 +521,7 @@ RUN  wget -O - ${GST_PLUGIN_VAAPI_REPO} | tar xJ && \
      make install
 
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 

--- a/XeonE3/centos-7.5/dldt+gst/Dockerfile
+++ b/XeonE3/centos-7.5/dldt+gst/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/XeonE3/centos-7.5/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/centos-7.5/ffmpeg+gst+dev/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -557,7 +557,7 @@ RUN  wget -O - ${GST_PLUGIN_VAAPI_REPO} | tar xJ && \
      make install
 
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 

--- a/XeonE3/centos-7.5/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/centos-7.5/ffmpeg+gst+dev/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/XeonE3/centos-7.5/ffmpeg/Dockerfile
+++ b/XeonE3/centos-7.5/ffmpeg/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/XeonE3/centos-7.5/ffmpeg/Dockerfile
+++ b/XeonE3/centos-7.5/ffmpeg/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/XeonE3/centos-7.5/gst/Dockerfile
+++ b/XeonE3/centos-7.5/gst/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/XeonE3/centos-7.5/gst/Dockerfile
+++ b/XeonE3/centos-7.5/gst/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/XeonE3/centos-7.5/nginx+rtmp/Dockerfile
+++ b/XeonE3/centos-7.5/nginx+rtmp/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/XeonE3/centos-7.5/nginx+rtmp/Dockerfile
+++ b/XeonE3/centos-7.5/nginx+rtmp/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.5.1804 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/XeonE3/centos-7.6/dldt+gst/Dockerfile
+++ b/XeonE3/centos-7.6/dldt+gst/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -521,7 +521,7 @@ RUN  wget -O - ${GST_PLUGIN_VAAPI_REPO} | tar xJ && \
      make install
 
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 

--- a/XeonE3/centos-7.6/dldt+gst/Dockerfile
+++ b/XeonE3/centos-7.6/dldt+gst/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/XeonE3/centos-7.6/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/centos-7.6/ffmpeg+gst+dev/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -557,7 +557,7 @@ RUN  wget -O - ${GST_PLUGIN_VAAPI_REPO} | tar xJ && \
      make install
 
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 

--- a/XeonE3/centos-7.6/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/centos-7.6/ffmpeg+gst+dev/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/XeonE3/centos-7.6/ffmpeg/Dockerfile
+++ b/XeonE3/centos-7.6/ffmpeg/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/XeonE3/centos-7.6/ffmpeg/Dockerfile
+++ b/XeonE3/centos-7.6/ffmpeg/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/XeonE3/centos-7.6/gst/Dockerfile
+++ b/XeonE3/centos-7.6/gst/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/XeonE3/centos-7.6/gst/Dockerfile
+++ b/XeonE3/centos-7.6/gst/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/XeonE3/centos-7.6/nginx+rtmp/Dockerfile
+++ b/XeonE3/centos-7.6/nginx+rtmp/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 
 # Install cmake
 ARG CMAKE_VER=3.13.1

--- a/XeonE3/centos-7.6/nginx+rtmp/Dockerfile
+++ b/XeonE3/centos-7.6/nginx+rtmp/Dockerfile
@@ -10,7 +10,7 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/XeonE3/ubuntu-16.04/dldt+gst/Dockerfile
+++ b/XeonE3/ubuntu-16.04/dldt+gst/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -532,7 +532,7 @@ RUN  wget -O - ${GST_PLUGIN_VAAPI_REPO} | tar xJ && \
      make install
 
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 RUN  DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev python-dev python-numpy

--- a/XeonE3/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/ubuntu-16.04/ffmpeg+gst+dev/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -560,7 +560,7 @@ RUN  wget -O - ${GST_PLUGIN_VAAPI_REPO} | tar xJ && \
      make install
 
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 RUN  DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev python-dev python-numpy

--- a/XeonE3/ubuntu-16.04/ffmpeg/Dockerfile
+++ b/XeonE3/ubuntu-16.04/ffmpeg/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/XeonE3/ubuntu-16.04/gst/Dockerfile
+++ b/XeonE3/ubuntu-16.04/gst/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/XeonE3/ubuntu-16.04/nginx+rtmp/Dockerfile
+++ b/XeonE3/ubuntu-16.04/nginx+rtmp/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:16.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/XeonE3/ubuntu-18.04/dldt+gst/Dockerfile
+++ b/XeonE3/ubuntu-18.04/dldt+gst/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -534,7 +534,7 @@ RUN  wget -O - ${GST_PLUGIN_VAAPI_REPO} | tar xJ && \
      make install
 
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 RUN  ln -sf /usr/share/zoneinfo/UTC /etc/localtime;

--- a/XeonE3/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
+++ b/XeonE3/ubuntu-18.04/ffmpeg+gst+dev/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 
@@ -562,7 +562,7 @@ RUN  wget -O - ${GST_PLUGIN_VAAPI_REPO} | tar xJ && \
      make install
 
 
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 RUN  ln -sf /usr/share/zoneinfo/UTC /etc/localtime;

--- a/XeonE3/ubuntu-18.04/ffmpeg/Dockerfile
+++ b/XeonE3/ubuntu-18.04/ffmpeg/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/XeonE3/ubuntu-18.04/gst/Dockerfile
+++ b/XeonE3/ubuntu-18.04/gst/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/XeonE3/ubuntu-18.04/nginx+rtmp/Dockerfile
+++ b/XeonE3/ubuntu-18.04/nginx+rtmp/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04 AS build
 WORKDIR /home
 
 # COMMON BUILD TOOLS
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 
 # Install cmake
 ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install
 

--- a/template/build-tools.m4
+++ b/template/build-tools.m4
@@ -2,7 +2,7 @@
 ifelse(index(DOCKER_IMAGE,ubuntu),-1,dnl
 RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
 ,dnl
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 )dnl
 
 include(cmake.m4)

--- a/template/build-tools.m4
+++ b/template/build-tools.m4
@@ -1,6 +1,6 @@
 # COMMON BUILD TOOLS
 ifelse(index(DOCKER_IMAGE,ubuntu),-1,dnl
-RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release;
+RUN yum install -y -q bzip2 make autoconf libtool git wget ca-certificates pkg-config gcc gcc-c++ bison flex patch epel-release yum-devel libcurl-devel zlib-devel;
 ,dnl
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends build-essential autoconf make git wget pciutils cpio libtool lsb-release ca-certificates pkg-config bison flex libcurl4-gnutls-dev zlib1g-dev
 )dnl

--- a/template/cmake.m4
+++ b/template/cmake.m4
@@ -3,6 +3,6 @@ ARG CMAKE_VER=3.13.1
 ARG CMAKE_REPO=https://cmake.org/files
 RUN wget -O - ${CMAKE_REPO}/v${CMAKE_VER%.*}/cmake-${CMAKE_VER}.tar.gz | tar xz && \
     cd cmake-${CMAKE_VER} && \
-    ./bootstrap --prefix="/usr" && \
+    ./bootstrap --prefix="/usr" --system-curl && \
     make -j8 && \
     make install

--- a/template/opencv.m4
+++ b/template/opencv.m4
@@ -1,4 +1,4 @@
-ARG OPENCV_VER=4.0.0
+ARG OPENCV_VER=4.1.0
 ARG OPENCV_REPO=https://github.com/opencv/opencv/archive/${OPENCV_VER}.tar.gz
 
 ifelse(index(DOCKER_IMAGE,ubuntu1604),-1,,


### PR DESCRIPTION
Hello, my name is Dmitry Smertn,
We needed to include support for the OpenCV G-API in our project. To do this, changed the version of OpenCV to the one used in OpenVINO R1 (OpenCV v4.1.0). Build OpenCV errors occurred when downloading additional frameworks that were fixed by adding options when installing cmake.
Please review my changes and add them to the source Dockerfile. No problems were found in the local build with changes.

Respectfully,
Dmitry Smertin