### PR TITLE
keep the include folder in the build stage

### DIFF
--- a/template/cleanup.m4
+++ b/template/cleanup.m4
@@ -1,7 +1,6 @@
 ifelse(index(DOCKER_IMAGE,-dev),-1,
 # Clean up after build
-RUN rm -rf /home/build/usr/include && \
-    rm -rf /home/build/usr/share/doc && \
+RUN rm -rf /home/build/usr/share/doc && \
     rm -rf /home/build/usr/share/gtk-doc && \
     rm -rf /home/build/usr/share/man && \
     find /home/build -name "*.a" -exec rm -f {} \;


### PR DESCRIPTION
Signed-off-by: Pengfei Qu <pengfei.qu@intel.com>

this will keep the include folder in the latest image. To help the app build as the base layer.