### PR TITLE
Fix for issue 211 - Auto exclusion of tests based on build options

### DIFF
--- a/script/gst-tests.cmake
+++ b/script/gst-tests.cmake
@@ -1,5 +1,11 @@
 file(GLOB tests "${DockerFiles_SOURCE_DIR}/test/gst_*.sh")
 foreach(test ${tests})
     get_filename_component(name ${test} NAME_WE)
+    if(NOT ${BUILD_MP3LAME} AND ${name} STREQUAL "gst_lamemp3")
+    #Do not add the gst_lamemp3 test if the flag BUILD_MP3LAME is OFF
+    elseif(NOT ${BUILD_FDKAAC} AND ${name} STREQUAL "gst_fdkaac")
+    #Do not add the gst_fdkaac test if the flag BUILD_FDKAAC is OFF
+    else()
     add_test(test_${image}_${name} "${CMAKE_CURRENT_SOURCE_DIR}/shell.sh" "/mnt/${name}.sh" "${image}")
+    endif()
 endforeach()


### PR DESCRIPTION
Test cases related to build options(i.e.-DBUILD_M……P3LAME=OFF, -DBUILD_FDKAAC=OFF) need to be auto excluded from the ctest #211 