### PR TITLE
hddl: remove the ov_hddl_run privileged requirement

### DIFF
--- a/VCAC-A/script/setup_hddl.sh
+++ b/VCAC-A/script/setup_hddl.sh
@@ -17,7 +17,7 @@ run_hddl_compose()
 gen_Dockercomposefile()
 {
     cat > docker-compose.yml <<EOF
-version: '3.7'
+version: '2.4'
 services:
   ov_hddl_init:
       image: openvisualcloud/vcaca-ubuntu1804-analytics-hddldaemon
@@ -26,17 +26,23 @@ services:
       volumes:
         - /usr/src:/usr/src:ro
         - /lib/modules:/lib/modules
+	- /etc/modules-load.d
       restart: on-failure
       privileged: true
   ov_hddl_run:
       image: openvisualcloud/vcaca-ubuntu1804-analytics-hddldaemon
       command: [ "/usr/local/bin/run_hddl.sh" ]
       container_name: ov_hddl_run
+      device_cgroup_rules:
+        - 'c 10:* rmw'
+        - 'c 89:* rmw'
+        - 'c 189:* rmw'
+        - 'c 180:* rmw'
       volumes:
-        - /lib/modules:/lib/modules:ro
+        - /dev:/dev
         - /var/tmp:/var/tmp
       restart: unless-stopped
-      privileged: true
+      privileged: false
 EOF
 }
 

--- a/VCAC-A/ubuntu-18.04/analytics/hddldaemon/init_hddl.sh
+++ b/VCAC-A/ubuntu-18.04/analytics/hddldaemon/init_hddl.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-modprobe i2c-dev i2c-i801 i2c-hid
-cd /opt/intel/openvino/deployment_tools/inference_engine/external/hddl/drivers
-bash setup.sh install
-
+modprobe -a i2c-dev i2c-i801 i2c-hid myd_ion myd_vsc
+if [ ! -c /dev/ion ]; then
+   cd /opt/intel/openvino/deployment_tools/inference_engine/external/hddl/drivers
+   bash setup.sh install
+fi

--- a/VCAC-A/ubuntu-18.04/analytics/hddldaemon/run_hddl.sh
+++ b/VCAC-A/ubuntu-18.04/analytics/hddldaemon/run_hddl.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 
-mount -t devtmpfs none /dev
-while [ ! -c /dev/ion ] ; 
-    do sleep 1; 
+while [ ! -c /dev/ion ] ; do
+	echo "waiting for myd_ion to be ready"
+	sleep 1
 done
-modprobe i2c-i801 i2c-dev i2c-hid myd_ion
 
 source /opt/intel/openvino/bin/setupvars.sh
 cd /opt/intel/openvino/deployment_tools/inference_engine/external/hddl/bin
 ./hddldaemon
-


### PR DESCRIPTION
* pass dynamic device by device-cgroup-rules
* use docker-compose 2.4 schema for device-cgroup-rules support
* fix the modprobe missing "-a" issue for multiple modules

Signed-off-by: Alek Du <alek.du@intel.com>