### PR TITLE
Remove sudo in build/shell scripts to avoid build timeout

### DIFF
--- a/VCAC-A/ubuntu-16.04/analytics/dev/Dockerfile
+++ b/VCAC-A/ubuntu-16.04/analytics/dev/Dockerfile
@@ -605,7 +605,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=ON -DENABLE_AVX2=ON -DENABLE_SSE42=ON \

--- a/VCAC-A/ubuntu-16.04/analytics/dev/Dockerfile
+++ b/VCAC-A/ubuntu-16.04/analytics/dev/Dockerfile
@@ -588,7 +588,6 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics
@@ -703,8 +702,6 @@ ENV PKG_CONFIG_PATH=/usr/local/lib/x86_64-linux-gnu/pkgconfig
 ENV LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/lib:/usr/lib
 ENV PATH=/usr/bin:${PATH}:/usr/local/bin
 ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
-ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/local/lib/x86_64-linux-gnu/girepository-1.0/
 ENV PYTHONPATH=${PYTHONPATH}:/opt/intel/dl_streamer/python
-ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
-ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
 
+ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/local/lib/x86_64-linux-gnu/girepository-1.0/

--- a/VCAC-A/ubuntu-16.04/analytics/gst/Dockerfile
+++ b/VCAC-A/ubuntu-16.04/analytics/gst/Dockerfile
@@ -600,7 +600,6 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics
@@ -686,8 +685,6 @@ ENV PKG_CONFIG_PATH=/usr/local/lib/x86_64-linux-gnu/pkgconfig
 ENV LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/lib:/usr/lib
 ENV PATH=/usr/bin:${PATH}:/usr/local/bin
 ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
-ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/local/lib/x86_64-linux-gnu/girepository-1.0/
 ENV PYTHONPATH=${PYTHONPATH}:/opt/intel/dl_streamer/python
-ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
-ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
 
+ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/local/lib/x86_64-linux-gnu/girepository-1.0/

--- a/VCAC-A/ubuntu-16.04/analytics/gst/Dockerfile
+++ b/VCAC-A/ubuntu-16.04/analytics/gst/Dockerfile
@@ -617,7 +617,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=ON -DENABLE_AVX2=ON -DENABLE_SSE42=ON \

--- a/VCAC-A/ubuntu-18.04/analytics/dev/Dockerfile
+++ b/VCAC-A/ubuntu-18.04/analytics/dev/Dockerfile
@@ -584,11 +584,51 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
+#Install va gstreamer plugins from source
+ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
+ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics
 
-#DL Streamer to be used
+RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
+    cd gst-video-analytics && \
+    git checkout ${VA_GSTREAMER_PLUGINS_VER} && \
+    git submodule init && git submodule update && \
+    mkdir build && \
+    cd build && \
+    export CFLAGS="-std=gnu99 -Wno-missing-field-initializers" && \
+    export CXXFLAGS="-std=c++11 -Wno-missing-field-initializers" && \
+    cmake \
+    -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
+    -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_PAHO_INSTALLATION=1 \
+    -DENABLE_RDKAFKA_INSTALLATION=1 \
+    -DHAVE_VAAPI=ON -DENABLE_AVX2=ON -DENABLE_SSE42=ON \
+    -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
+    make -j4
+RUN mkdir -p build/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0 && \
+    cp -r gst-video-analytics/build/intel64/Release/lib/* build/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
+RUN mkdir -p /usr/local/lib/x86_64-linux-gnu/gstreamer-1.0 && \
+    cp -r gst-video-analytics/build/intel64/Release/lib/* /usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
 ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
-ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/opt/intel/openvino/data_processing/dl_streamer/lib/
 
+RUN mkdir -p build/opt/intel/dl_streamer/python && \
+    cp -r gst-video-analytics/python/* build/opt/intel/dl_streamer/python
+RUN mkdir -p /opt/intel/dl_streamer/python && \
+    cp -r gst-video-analytics/python/* /opt/intel/dl_streamer/python
+ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
+ENV PYTHONPATH=${PYTHONPATH}:/opt/intel/dl_streamer/python
+
+# Build gstreamer python
+ARG GST_VER=1.16.0
+ARG GST_PYTHON_REPO=https://gstreamer.freedesktop.org/src/gst-python/gst-python-${GST_VER}.tar.xz
+RUN wget -O - ${GST_PYTHON_REPO} | tar xJ && \
+    cd gst-python-${GST_VER} && \
+    ./autogen.sh --prefix=/usr/local --libdir=/usr/local/lib/x86_64-linux-gnu --libexecdir=/usr/local/lib/x86_64-linux-gnu --with-pygi-overrides-dir=/usr/lib/python3/dist-packages/gi/overrides --disable-dependency-tracking --disable-silent-rules --with-libpython-dir="/usr/lib/x86_64-linux-gnu/" PYTHON=/usr/bin/python3 && \
+    make -j $(nproc) && \
+    make install && \
+    make install DESTDIR=/home/build
+
+ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/local/lib/x86_64-linux-gnu/girepository-1.0/
 
 
 # Fetch FFmpeg source
@@ -659,8 +699,6 @@ ENV PKG_CONFIG_PATH=/usr/local/lib/x86_64-linux-gnu/pkgconfig
 ENV LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/lib:/usr/lib
 ENV PATH=/usr/bin:${PATH}:/usr/local/bin
 ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
-ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/opt/intel/openvino/data_processing/dl_streamer/lib/
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/intel/openvino/data_processing/dl_streamer/lib/:/opt/intel/openvino/opencv/lib/
-ENV PYTHONPATH=${PYTHONPATH}:/opt/intel/openvino/data_processing/dl_streamer/python
-ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/local/lib/x86_64-linux-gnu/girepository-1.0/
+ENV PYTHONPATH=${PYTHONPATH}:/opt/intel/dl_streamer/python
 
+ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/local/lib/x86_64-linux-gnu/girepository-1.0/

--- a/VCAC-A/ubuntu-18.04/analytics/gst/Dockerfile
+++ b/VCAC-A/ubuntu-18.04/analytics/gst/Dockerfile
@@ -492,8 +492,6 @@ RUN cd /opt/intel/openvino/deployment_tools/tools/deployment_manager/   && \
     ./deployment_manager.py --targets hddl vpu cpu                      && \
     cd /root/ && ls -lh && mkdir -p openvino                            && \
     tar zvxf openvino_deploy_package.tar.gz -C openvino
-RUN cp -r /opt/intel/openvino/data_processing /root/openvino		&& \
-    cp -r /opt/intel/openvino/opencv /root/openvino
 
 #Copy over directories to clean image
 RUN mkdir -p /home/build/usr/local/lib && \
@@ -568,11 +566,51 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
+#Install va gstreamer plugins from source
+ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
+ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics
 
-#DL Streamer to be used
+RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
+    cd gst-video-analytics && \
+    git checkout ${VA_GSTREAMER_PLUGINS_VER} && \
+    git submodule init && git submodule update && \
+    mkdir build && \
+    cd build && \
+    export CFLAGS="-std=gnu99 -Wno-missing-field-initializers" && \
+    export CXXFLAGS="-std=c++11 -Wno-missing-field-initializers" && \
+    cmake \
+    -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
+    -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_PAHO_INSTALLATION=1 \
+    -DENABLE_RDKAFKA_INSTALLATION=1 \
+    -DHAVE_VAAPI=ON -DENABLE_AVX2=ON -DENABLE_SSE42=ON \
+    -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
+    make -j4
+RUN mkdir -p build/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0 && \
+    cp -r gst-video-analytics/build/intel64/Release/lib/* build/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
+RUN mkdir -p /usr/local/lib/x86_64-linux-gnu/gstreamer-1.0 && \
+    cp -r gst-video-analytics/build/intel64/Release/lib/* /usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
 ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
-ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/opt/intel/openvino/data_processing/dl_streamer/lib/
 
+RUN mkdir -p build/opt/intel/dl_streamer/python && \
+    cp -r gst-video-analytics/python/* build/opt/intel/dl_streamer/python
+RUN mkdir -p /opt/intel/dl_streamer/python && \
+    cp -r gst-video-analytics/python/* /opt/intel/dl_streamer/python
+ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
+ENV PYTHONPATH=${PYTHONPATH}:/opt/intel/dl_streamer/python
+
+# Build gstreamer python
+ARG GST_VER=1.16.0
+ARG GST_PYTHON_REPO=https://gstreamer.freedesktop.org/src/gst-python/gst-python-${GST_VER}.tar.xz
+RUN wget -O - ${GST_PYTHON_REPO} | tar xJ && \
+    cd gst-python-${GST_VER} && \
+    ./autogen.sh --prefix=/usr/local --libdir=/usr/local/lib/x86_64-linux-gnu --libexecdir=/usr/local/lib/x86_64-linux-gnu --with-pygi-overrides-dir=/usr/lib/python3/dist-packages/gi/overrides --disable-dependency-tracking --disable-silent-rules --with-libpython-dir="/usr/lib/x86_64-linux-gnu/" PYTHON=/usr/bin/python3 && \
+    make -j $(nproc) && \
+    make install && \
+    make install DESTDIR=/home/build
+
+ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/local/lib/x86_64-linux-gnu/girepository-1.0/
 
 
 # Clean up after build
@@ -614,8 +652,6 @@ ENV PKG_CONFIG_PATH=/usr/local/lib/x86_64-linux-gnu/pkgconfig
 ENV LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/lib:/usr/lib
 ENV PATH=/usr/bin:${PATH}:/usr/local/bin
 ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
-ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/opt/intel/openvino/data_processing/dl_streamer/lib/
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/intel/openvino/data_processing/dl_streamer/lib/:/opt/intel/openvino/opencv/lib/
-ENV PYTHONPATH=${PYTHONPATH}:/opt/intel/openvino/data_processing/dl_streamer/python
-ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/local/lib/x86_64-linux-gnu/girepository-1.0/
+ENV PYTHONPATH=${PYTHONPATH}:/opt/intel/dl_streamer/python
 
+ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/local/lib/x86_64-linux-gnu/girepository-1.0/

--- a/Xeon/centos-7.4/analytics/dev/Dockerfile
+++ b/Xeon/centos-7.4/analytics/dev/Dockerfile
@@ -606,7 +606,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/Xeon/centos-7.4/analytics/dev/Dockerfile
+++ b/Xeon/centos-7.4/analytics/dev/Dockerfile
@@ -589,7 +589,6 @@ RUN if [ "$PAHO_INSTALL" = "true" ] ; then \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/Xeon/centos-7.4/analytics/gst/Dockerfile
+++ b/Xeon/centos-7.4/analytics/gst/Dockerfile
@@ -563,7 +563,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/Xeon/centos-7.4/analytics/gst/Dockerfile
+++ b/Xeon/centos-7.4/analytics/gst/Dockerfile
@@ -546,7 +546,6 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/Xeon/centos-7.5/analytics/dev/Dockerfile
+++ b/Xeon/centos-7.5/analytics/dev/Dockerfile
@@ -605,7 +605,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/Xeon/centos-7.5/analytics/dev/Dockerfile
+++ b/Xeon/centos-7.5/analytics/dev/Dockerfile
@@ -588,7 +588,6 @@ RUN if [ "$PAHO_INSTALL" = "true" ] ; then \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/Xeon/centos-7.5/analytics/gst/Dockerfile
+++ b/Xeon/centos-7.5/analytics/gst/Dockerfile
@@ -545,7 +545,6 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/Xeon/centos-7.5/analytics/gst/Dockerfile
+++ b/Xeon/centos-7.5/analytics/gst/Dockerfile
@@ -562,7 +562,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/Xeon/centos-7.6/analytics/dev/Dockerfile
+++ b/Xeon/centos-7.6/analytics/dev/Dockerfile
@@ -605,7 +605,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/Xeon/centos-7.6/analytics/dev/Dockerfile
+++ b/Xeon/centos-7.6/analytics/dev/Dockerfile
@@ -588,7 +588,6 @@ RUN if [ "$PAHO_INSTALL" = "true" ] ; then \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/Xeon/centos-7.6/analytics/gst/Dockerfile
+++ b/Xeon/centos-7.6/analytics/gst/Dockerfile
@@ -545,7 +545,6 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/Xeon/centos-7.6/analytics/gst/Dockerfile
+++ b/Xeon/centos-7.6/analytics/gst/Dockerfile
@@ -562,7 +562,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/Xeon/ubuntu-16.04/analytics/dev/Dockerfile
+++ b/Xeon/ubuntu-16.04/analytics/dev/Dockerfile
@@ -593,7 +593,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/Xeon/ubuntu-16.04/analytics/dev/Dockerfile
+++ b/Xeon/ubuntu-16.04/analytics/dev/Dockerfile
@@ -576,7 +576,6 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/Xeon/ubuntu-16.04/analytics/gst/Dockerfile
+++ b/Xeon/ubuntu-16.04/analytics/gst/Dockerfile
@@ -552,7 +552,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/Xeon/ubuntu-16.04/analytics/gst/Dockerfile
+++ b/Xeon/ubuntu-16.04/analytics/gst/Dockerfile
@@ -535,7 +535,6 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/Xeon/ubuntu-18.04/analytics/dev/Dockerfile
+++ b/Xeon/ubuntu-18.04/analytics/dev/Dockerfile
@@ -596,7 +596,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/Xeon/ubuntu-18.04/analytics/dev/Dockerfile
+++ b/Xeon/ubuntu-18.04/analytics/dev/Dockerfile
@@ -579,7 +579,6 @@ RUN if [ "$PAHO_INSTALL" = "true" ] ; then \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/Xeon/ubuntu-18.04/analytics/gst/Dockerfile
+++ b/Xeon/ubuntu-18.04/analytics/gst/Dockerfile
@@ -553,7 +553,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/Xeon/ubuntu-18.04/analytics/gst/Dockerfile
+++ b/Xeon/ubuntu-18.04/analytics/gst/Dockerfile
@@ -536,7 +536,6 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/XeonE3/centos-7.4/analytics/dev/Dockerfile
+++ b/XeonE3/centos-7.4/analytics/dev/Dockerfile
@@ -724,7 +724,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/XeonE3/centos-7.4/analytics/dev/Dockerfile
+++ b/XeonE3/centos-7.4/analytics/dev/Dockerfile
@@ -707,7 +707,6 @@ RUN if [ "$PAHO_INSTALL" = "true" ] ; then \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/XeonE3/centos-7.4/analytics/gst/Dockerfile
+++ b/XeonE3/centos-7.4/analytics/gst/Dockerfile
@@ -672,7 +672,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/XeonE3/centos-7.4/analytics/gst/Dockerfile
+++ b/XeonE3/centos-7.4/analytics/gst/Dockerfile
@@ -655,7 +655,6 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/XeonE3/centos-7.5/analytics/dev/Dockerfile
+++ b/XeonE3/centos-7.5/analytics/dev/Dockerfile
@@ -706,7 +706,6 @@ RUN if [ "$PAHO_INSTALL" = "true" ] ; then \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/XeonE3/centos-7.5/analytics/dev/Dockerfile
+++ b/XeonE3/centos-7.5/analytics/dev/Dockerfile
@@ -723,7 +723,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/XeonE3/centos-7.5/analytics/gst/Dockerfile
+++ b/XeonE3/centos-7.5/analytics/gst/Dockerfile
@@ -671,7 +671,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/XeonE3/centos-7.5/analytics/gst/Dockerfile
+++ b/XeonE3/centos-7.5/analytics/gst/Dockerfile
@@ -654,7 +654,6 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/XeonE3/centos-7.6/analytics/dev/Dockerfile
+++ b/XeonE3/centos-7.6/analytics/dev/Dockerfile
@@ -706,7 +706,6 @@ RUN if [ "$PAHO_INSTALL" = "true" ] ; then \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/XeonE3/centos-7.6/analytics/dev/Dockerfile
+++ b/XeonE3/centos-7.6/analytics/dev/Dockerfile
@@ -723,7 +723,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/XeonE3/centos-7.6/analytics/gst/Dockerfile
+++ b/XeonE3/centos-7.6/analytics/gst/Dockerfile
@@ -671,7 +671,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/XeonE3/centos-7.6/analytics/gst/Dockerfile
+++ b/XeonE3/centos-7.6/analytics/gst/Dockerfile
@@ -654,7 +654,6 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/XeonE3/ubuntu-16.04/analytics/dev/Dockerfile
+++ b/XeonE3/ubuntu-16.04/analytics/dev/Dockerfile
@@ -704,7 +704,6 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/XeonE3/ubuntu-16.04/analytics/dev/Dockerfile
+++ b/XeonE3/ubuntu-16.04/analytics/dev/Dockerfile
@@ -721,7 +721,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/XeonE3/ubuntu-16.04/analytics/gst/Dockerfile
+++ b/XeonE3/ubuntu-16.04/analytics/gst/Dockerfile
@@ -667,7 +667,6 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/XeonE3/ubuntu-16.04/analytics/gst/Dockerfile
+++ b/XeonE3/ubuntu-16.04/analytics/gst/Dockerfile
@@ -684,7 +684,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/XeonE3/ubuntu-18.04/analytics/dev/Dockerfile
+++ b/XeonE3/ubuntu-18.04/analytics/dev/Dockerfile
@@ -724,7 +724,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/XeonE3/ubuntu-18.04/analytics/dev/Dockerfile
+++ b/XeonE3/ubuntu-18.04/analytics/dev/Dockerfile
@@ -707,7 +707,6 @@ RUN if [ "$PAHO_INSTALL" = "true" ] ; then \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/XeonE3/ubuntu-18.04/analytics/gst/Dockerfile
+++ b/XeonE3/ubuntu-18.04/analytics/gst/Dockerfile
@@ -685,7 +685,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=1 \
     -DHAVE_VAAPI=OFF  \

--- a/XeonE3/ubuntu-18.04/analytics/gst/Dockerfile
+++ b/XeonE3/ubuntu-18.04/analytics/gst/Dockerfile
@@ -668,7 +668,6 @@ RUN wget -O - ${LIBRDKAFKA_REPO} | tar xz && \
 
 
 
-
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics

--- a/doc/ffmpeg.md
+++ b/doc/ffmpeg.md
@@ -10,7 +10,7 @@ The FFmpeg docker images are compiled with the following audio and video codecs:
 |mp3lame|3.100|vpx|1.7.0|
 |opus|1.2.1|dav1d|0.5.2|
 |ogg|1.3.3|SVT-HEVC|v1.4.3|
-|vorbis|1.3.6|SVT-AV1|v0.8.1|
+|vorbis|1.3.6|SVT-AV1|v0.8.3|
 |x264|stable|SVT-VP9*|v0.1.0|
 
 \* SVT-VP9 encoder app only. SVT-VP9 not yet available as a FFmpeg plugin. 

--- a/doc/gst.md
+++ b/doc/gst.md
@@ -12,7 +12,7 @@ The GStreamer docker images are compiled with the following plugin set:
 |`gst-plugin-vaapi`|1.16.0|`gst-plugin-libav`|1.16.0|
 |`gst-video-analytics`|0.7.0|`SVT-HEVC encoder`|v1.4.3|
 |`gst-python`|1.16.0|`SVT-VP9 encoder`|v0.1.0|
-|||`SVT-AV1 encoder`|v0.8.1|
+|||`SVT-AV1 encoder`|v0.8.3|
 
 ---
 

--- a/doc/svt.md
+++ b/doc/svt.md
@@ -7,7 +7,7 @@ SVT Images get built with following SVT transcoders
 |Module|Version|Comment
 |------|------|------|
 |SVT-HEVC|v1.4.3|HEVC-compliant encoder library core that achieves excellent density-quality tradeoffs|
-|SVT-AV1|v0.8.1|AV1 Compliant encoder library for VOD and Live encoding / transcoding video applications|
+|SVT-AV1|v0.8.3|AV1 Compliant encoder library for VOD and Live encoding / transcoding video applications|
 |SVT-VP9|v0.1.0|VP9 Compliant encoder library for VOD and Live encoding / transcoding video applications|
 
 ### Evaluate SVT 

--- a/script/build.sh
+++ b/script/build.sh
@@ -32,10 +32,10 @@ fi
 if [[ ${UPDATE_DOCKERFILES} == OFF ]]; then
     build_args=$(env | cut -f1 -d= | grep -E '_(proxy|REPO|VER)$' | sed 's/^/--build-arg /')
     if grep -q 'AS build' "${DIR}/Dockerfile"; then
-        sudo -E docker build --network=host ${BUILD_CACHE} --target build -t "${DOCKER_PREFIX}/${IMAGE}:build" "$DIR" $build_args
+        docker build --network=host ${BUILD_CACHE} --target build -t "${DOCKER_PREFIX}/${IMAGE}:build" "$DIR" $build_args
     fi
 
-    sudo -E docker build --network=host ${FULL_CACHE} -t "${DOCKER_PREFIX}/${IMAGE}:${BUILD_VERSION}" -t "${DOCKER_PREFIX}/${IMAGE}:latest" "$DIR" $build_args
+    docker build --network=host ${FULL_CACHE} -t "${DOCKER_PREFIX}/${IMAGE}:${BUILD_VERSION}" -t "${DOCKER_PREFIX}/${IMAGE}:latest" "$DIR" $build_args
 elif [[ ${UPDATE_DOCKERHUB_README} == ON ]]; then
     README_FILEPATH="$(echo "$PWD/README.md" | sed 's/build\///')"
     ${SCRIPT_ROOT}/update-dockerhub-readme.sh ${DOCKER_PREFIX} ${IMAGE} ${README_FILEPATH}

--- a/script/qatbuild.sh
+++ b/script/qatbuild.sh
@@ -8,7 +8,7 @@ fi
 if test -d /opt/intel/QAT; then
    if test ! -f "${DIR}/qat.tar.gz"; then
        sudo tar cfz "${DIR}/qat.tar.gz" /opt/intel/QAT/build $(find /opt/intel/QAT -name "*.h") /etc/udev/rules.d/00-qat.rules --exclude /opt/intel/QAT/*.tar.gz
-       sudo chmod $(id -u).$(id -g) "${DIR}/qat.tar.gz"
+       sudo chown $(id -u).$(id -g) "${DIR}/qat.tar.gz"
    fi
    export QAT_GID_VER=$(getent group qat | cut -f3 -d:)
    . "${DIR}/../../../../script/build.sh"

--- a/script/shell.sh
+++ b/script/shell.sh
@@ -16,7 +16,7 @@ if [[ -z $TRAVIS && -z $JENKINS_URL ]]; then DOCKER_IT="-it"; else DOCKER_IT="";
 TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)/../test/"
 
 if [[ $IMAGE == *vcaca* ]]; then
-    sudo -E docker run $DEVICE_DIR --rm --user root --privileged -v /var/tmp:/var/tmp -v "${TEST}:/mnt:ro" $(env | cut -f1 -d= | grep -E '_(proxy|REPO|VER)$' | sed 's/^/-e /') $(grep '^ARG .*=' "${DIR}/Dockerfile" | sed 's/^ARG \([^=]*\)=.*/-e \1/') $DOCKER_IT "${DOCKER_PREFIX}/${IMAGE}" "${@:-/bin/bash}"
+    docker run $DEVICE_DIR --rm --user root --privileged -v /var/tmp:/var/tmp -v "${TEST}:/mnt:ro" $(env | cut -f1 -d= | grep -E '_(proxy|REPO|VER)$' | sed 's/^/-e /') $(grep '^ARG .*=' "${DIR}/Dockerfile" | sed 's/^ARG \([^=]*\)=.*/-e \1/') $DOCKER_IT "${DOCKER_PREFIX}/${IMAGE}" "${@:-/bin/bash}"
 else
-    sudo -E docker run $DEVICE_DIR --rm -v "${TEST}:/mnt:ro" $(env | cut -f1 -d= | grep -E '_(proxy|REPO|VER)$' | sed 's/^/-e /') $(grep '^ARG .*=' "${DIR}/Dockerfile" | sed 's/^ARG \([^=]*\)=.*/-e \1/') $DOCKER_IT "${DOCKER_PREFIX}/${IMAGE}" "${@:-/bin/bash}"
+    docker run $DEVICE_DIR --rm -v "${TEST}:/mnt:ro" $(env | cut -f1 -d= | grep -E '_(proxy|REPO|VER)$' | sed 's/^/-e /') $(grep '^ARG .*=' "${DIR}/Dockerfile" | sed 's/^ARG \([^=]*\)=.*/-e \1/') $DOCKER_IT "${DOCKER_PREFIX}/${IMAGE}" "${@:-/bin/bash}"
 fi

--- a/template/gstreamer-videoanalytics.m4
+++ b/template/gstreamer-videoanalytics.m4
@@ -53,7 +53,6 @@ ifelse(RDKAFKA_INSTALLED,true,,dnl
 include(librdkafka.m4)
 )
 
-define(`BUILD_VA_GSTREAMER',dnl
 #Install va gstreamer plugins from source
 ARG VA_GSTREAMER_PLUGINS_VER=v1.0.0 
 ARG VA_GSTREAMER_PLUGINS_REPO=https://github.com/opencv/gst-video-analytics
@@ -102,17 +101,6 @@ ifelse(index(DOCKER_IMAGE,centos),-1,,
 ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/lib64/girepository-1.0/:/usr/local/lib64/girepository-1.0/)dnl
 ifelse(index(DOCKER_IMAGE,ubuntu),-1,,
 ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/local/lib/x86_64-linux-gnu/girepository-1.0/)dnl
-)dnl
-
-ifelse(index(DOCKER_IMAGE,vcaca),-1,
-defn(`BUILD_VA_GSTREAMER'),
-ifelse(index(DOCKER_IMAGE,ubuntu1804),-1,
-defn(`BUILD_VA_GSTREAMER'),
-#DL Streamer to be used
-ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/usr/local/ifelse(index(DOCKER_IMAGE,ubuntu),-1,lib64,lib/x86_64-linux-gnu)/gstreamer-1.0
-ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/opt/intel/openvino/data_processing/dl_streamer/lib/
-)dnl
-)dnl
 
 define(`INSTALL_PKGS_VA_GST_PLUGINS',
 ifelse(index(DOCKER_IMAGE,ubuntu1604),-1,,
@@ -132,24 +120,10 @@ ENV PKG_CONFIG_PATH=/usr/local/ifelse(index(DOCKER_IMAGE,ubuntu),-1,lib64,lib/x8
 ENV LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/lib:/usr/lib
 ENV PATH=/usr/bin:${PATH}:/usr/local/bin
 ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/usr/local/ifelse(index(DOCKER_IMAGE,ubuntu),-1,lib64,lib/x86_64-linux-gnu)/gstreamer-1.0
-ifelse(index(DOCKER_IMAGE,vcaca),-1,
 ENV PYTHONPATH=${PYTHONPATH}:/opt/intel/dl_streamer/python
 ifelse(index(DOCKER_IMAGE,centos),-1,,
 ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/lib64/girepository-1.0/:/usr/local/lib64/girepository-1.0/
 RUN python3 -m pip install numpy)
 ifelse(index(DOCKER_IMAGE,ubuntu),-1,,
 ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/local/lib/x86_64-linux-gnu/girepository-1.0/)dnl
-,
-ifelse(index(DOCKER_IMAGE,1804),-1,
-ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/local/lib/x86_64-linux-gnu/girepository-1.0/
-ENV PYTHONPATH=${PYTHONPATH}:/opt/intel/dl_streamer/python
-ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
-ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
-,
-ENV GST_PLUGIN_PATH=${GST_PLUGIN_PATH}:/opt/intel/openvino/data_processing/dl_streamer/lib/
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/intel/openvino/data_processing/dl_streamer/lib/:/opt/intel/openvino/opencv/lib/
-ENV PYTHONPATH=${PYTHONPATH}:/opt/intel/openvino/data_processing/dl_streamer/python
-ENV GI_TYPELIB_PATH=${GI_TYPELIB_PATH}:/usr/local/lib/x86_64-linux-gnu/girepository-1.0/
-)dnl
-)dnl
 )dnl

--- a/template/gstreamer-videoanalytics.m4
+++ b/template/gstreamer-videoanalytics.m4
@@ -70,7 +70,6 @@ RUN git clone ${VA_GSTREAMER_PLUGINS_REPO} && \
     -DVERSION_PATCH=$(echo "$(git rev-list --count --first-parent HEAD)") \
     -DGIT_INFO=$(echo "git_$(git rev-parse --short HEAD)") \
     -DCMAKE_BUILD_TYPE=Release \
-    -DDISABLE_SAMPLES=ON \
     -DENABLE_PAHO_INSTALLATION=1 \
     -DENABLE_RDKAFKA_INSTALLATION=ifelse(RDKAFKA_INSTALLED,true,1,0) \
     ifelse(index(DOCKER_IMAGE,vcaca),-1,-DHAVE_VAAPI=OFF ,-DHAVE_VAAPI=ON -DENABLE_AVX2=ON -DENABLE_SSE42=ON) \

--- a/template/openvino.binary.m4
+++ b/template/openvino.binary.m4
@@ -85,11 +85,7 @@ RUN cd /opt/intel/openvino/deployment_tools/tools/deployment_manager/   && \
     ./deployment_manager.py --targets hddl vpu cpu                      && \
     cd /root/ && ls -lh && mkdir -p openvino                            && \
     tar zvxf openvino_deploy_package.tar.gz -C openvino
-ifelse(index(DOCKER_IMAGE,gst),-1,,
-
-RUN cp -r /opt/intel/openvino/data_processing /root/openvino		&& \
-    cp -r /opt/intel/openvino/opencv /root/openvino
-),dnl
+,dnl
 RUN cd /opt/intel/openvino/deployment_tools/tools/deployment_manager && \
     python3 deployment_manager.py --targets=hddl --output_dir=/home --archive_name=hddl && \
     mkdir -p /home/opt/intel/openvino && \


### PR DESCRIPTION
Requires the regular user to be in the docker group: usermod -aG docker <username>.
Running docker as regular users does carry certain security implications but this is a recommended solution by docker. Besides, login as a regular user carries a lot more benefit than as a root. The QAT build still requires a one-time sudo to archive the QAT system files. 

BTW, it is patched against v20.4. The patch modifies only 2 files: build.sh and shell.sh. 
