### PR TITLE
remove sudo in build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,6 @@ build.sh:
 ```bash
 for dep in .2 .1; do   
     image=$(grep -m1 '#' "Dockerfile$dep" | cut -d' ' -f2)   
-    sudo docker build --network=host --file="Dockerfile$dep" -t "$image:latest" . $(env | grep -E '_(proxy)=' | sed 's/^/--build-arg /')   
+    docker build --network=host --file="Dockerfile$dep" -t "$image:latest" . $(env | grep -E '_(proxy)=' | sed 's/^/--build-arg /')   
 done  
 ```

--- a/VCA2/README.md
+++ b/VCA2/README.md
@@ -6,13 +6,6 @@ See the following documents for instructions on how to setup Intel VCA 2:
 
 The Dockerfiles presented in this repo are targeted to run on the Intel VCA 2 nodes. Therefore the host installation steps mentioned in the parent [README.md](../README.md) apply to each Intel VCA 2 node instead. 
 
-The build and test scripts additionally require "sudo" to be available on the node:
-
-```sh
-Ubuntu: apt-get install -y sudo 
-CentOS: yum install -y sudo
-```
-
 ### GPU Dockers:
 
 VAAPI expects rendering device to be set in order to work. Dockers readily spin up with this config. Specify the display device on host by doing following.

--- a/script/build.sh
+++ b/script/build.sh
@@ -32,10 +32,10 @@ fi
 if [[ ${UPDATE_DOCKERFILES} == OFF ]]; then
     build_args=$(env | cut -f1 -d= | grep -E '_(proxy|REPO|VER)$' | sed 's/^/--build-arg /')
     if grep -q 'AS build' "${DIR}/Dockerfile"; then
-        sudo -E docker build --network=host ${BUILD_CACHE} --target build -t "${DOCKER_PREFIX}/${IMAGE}:build" "$DIR" $build_args
+        docker build --network=host ${BUILD_CACHE} --target build -t "${DOCKER_PREFIX}/${IMAGE}:build" "$DIR" $build_args
     fi
 
-    sudo -E docker build --network=host ${FULL_CACHE} -t "${DOCKER_PREFIX}/${IMAGE}:${BUILD_VERSION}" -t "${DOCKER_PREFIX}/${IMAGE}:latest" "$DIR" $build_args
+    docker build --network=host ${FULL_CACHE} -t "${DOCKER_PREFIX}/${IMAGE}:${BUILD_VERSION}" -t "${DOCKER_PREFIX}/${IMAGE}:latest" "$DIR" $build_args
 elif [[ ${UPDATE_DOCKERHUB_README} == ON ]]; then
     README_FILEPATH="$(echo "$PWD/README.md" | sed 's/build\///')"
     ${SCRIPT_ROOT}/update-dockerhub-readme.sh ${DOCKER_PREFIX} ${IMAGE} ${README_FILEPATH}

--- a/script/qatbuild.sh
+++ b/script/qatbuild.sh
@@ -7,8 +7,7 @@ fi
 
 if test -d /opt/intel/QAT; then
    if test ! -f "${DIR}/qat.tar.gz"; then
-       sudo tar cfz "${DIR}/qat.tar.gz" /opt/intel/QAT/build $(find /opt/intel/QAT -name "*.h") /etc/udev/rules.d/00-qat.rules --exclude /opt/intel/QAT/*.tar.gz
-       sudo chown $(id -u).$(id -g) "${DIR}/qat.tar.gz"
+       docker run --rm -v /opt/intel/QAT:/opt/intel/QAT:ro -v /etc/udev:/etc/udev:ro -v "${DIR}:/home:rw" -it busybox /bin/sh -c "tar cfz /home/qat.tar.gz /opt/intel/QAT/build \$(find /opt/intel/QAT -name '*.h') /etc/udev/rules.d/00-qat.rules --exclude /opt/intel/QAT/*.tar.gz && chown $(id -u).$(id -g) /home/qat.tar.gz"
    fi
    export QAT_GID_VER=$(getent group qat | cut -f3 -d:)
    . "${DIR}/../../../../script/build.sh"

--- a/script/shell.sh
+++ b/script/shell.sh
@@ -16,7 +16,7 @@ if [[ -z $TRAVIS && -z $JENKINS_URL ]]; then DOCKER_IT="-it"; else DOCKER_IT="";
 TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)/../test/"
 
 if [[ $IMAGE == *vcaca* ]]; then
-    sudo -E docker run $DEVICE_DIR --rm --user root --privileged -v /var/tmp:/var/tmp -v "${TEST}:/mnt:ro" $(env | cut -f1 -d= | grep -E '_(proxy|REPO|VER)$' | sed 's/^/-e /') $(grep '^ARG .*=' "${DIR}/Dockerfile" | sed 's/^ARG \([^=]*\)=.*/-e \1/') $DOCKER_IT "${DOCKER_PREFIX}/${IMAGE}" "${@:-/bin/bash}"
+    docker run $DEVICE_DIR --rm --user root --privileged -v /var/tmp:/var/tmp -v "${TEST}:/mnt:ro" $(env | cut -f1 -d= | grep -E '_(proxy|REPO|VER)$' | sed 's/^/-e /') $(grep '^ARG .*=' "${DIR}/Dockerfile" | sed 's/^ARG \([^=]*\)=.*/-e \1/') $DOCKER_IT "${DOCKER_PREFIX}/${IMAGE}" "${@:-/bin/bash}"
 else
-    sudo -E docker run $DEVICE_DIR --rm -v "${TEST}:/mnt:ro" $(env | cut -f1 -d= | grep -E '_(proxy|REPO|VER)$' | sed 's/^/-e /') $(grep '^ARG .*=' "${DIR}/Dockerfile" | sed 's/^ARG \([^=]*\)=.*/-e \1/') $DOCKER_IT "${DOCKER_PREFIX}/${IMAGE}" "${@:-/bin/bash}"
+    docker run $DEVICE_DIR --rm -v "${TEST}:/mnt:ro" $(env | cut -f1 -d= | grep -E '_(proxy|REPO|VER)$' | sed 's/^/-e /') $(grep '^ARG .*=' "${DIR}/Dockerfile" | sed 's/^ARG \([^=]*\)=.*/-e \1/') $DOCKER_IT "${DOCKER_PREFIX}/${IMAGE}" "${@:-/bin/bash}"
 fi


### PR DESCRIPTION
Requires the regular user to be in the docker group: usermod -aG docker .

Running docker as regular users does carry certain security implications but this is a recommended solution by docker. Besides, login as a regular user carries a lot more benefit than as a root. Plus, there is no sudo timeout if the build process is long. 