### PR TITLE
gvapython fix for VCAC-A U18 and OpenCV Upgrade to 4.5.1

### DIFF
--- a/template/components/opencv.m4
+++ b/template/components/opencv.m4
@@ -30,7 +30,7 @@ dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 dnl
 include(begin.m4)
 
-DECLARE(`OPENCV_VER',4.5.0)
+DECLARE(`OPENCV_VER',4.5.1)
 
 ifelse(OS_NAME,ubuntu,`
 define(`OPENCV_BUILD_DEPS',`ca-certificates ifdef(`BUILD_CMAKE',,cmake) gcc g++ make wget python3-numpy ccache libeigen3-dev')

--- a/template/components/openvino.m4
+++ b/template/components/openvino.m4
@@ -36,7 +36,7 @@ DECLARE(`OPENVINO_BUILD_NO',17504)
 
 ifelse(OS_NAME,ubuntu,`
 define(`OPENVINO_BUILD_DEPS',`cpio libjson-c-dev')
-define(`OPENVINO_INSTALL_DEPS',`libusb-1.0-0-dev ifelse(OS_VERSION,20.04,libboost-filesystem1.67.0 libboost-system1.67.0 libboost-program-options1.67.0 libjson-c4,libboost-filesystem1.65.1 libboost-system1.65.1 libboost-program-options1.65.1 libjson-c3)')
+define(`OPENVINO_INSTALL_DEPS',`libusb-1.0-0-dev ifelse(OS_VERSION,20.04,libboost-filesystem1.71.0 libboost-system1.71.0 libboost-program-options1.71.0 libjson-c4,libboost-filesystem1.65.1 libboost-system1.65.1 libboost-program-options1.65.1 libjson-c3)')
 ')
 
 define(`BUILD_OPENVINO',`

--- a/template/components/vcaca-gst-gva.m4
+++ b/template/components/vcaca-gst-gva.m4
@@ -31,7 +31,7 @@ dnl
 include(begin.m4)
 
 ifelse(OS_NAME,ubuntu,`
-define(`GVA_INSTALL_DEPS',`python3-numpy python3-gi python3-gi-cairo python3-dev ifelse(OS_VERSION,20.04,libwayland-egl1 libegl1-mesa)')
+define(`GVA_INSTALL_DEPS',`python3-numpy python3-gi python3-gi-cairo python3-dev ocl-icd-opencl-dev ifelse(OS_VERSION,20.04,libwayland-egl1 libegl1-mesa)')
 ')
 
 define(`BUILD_GVA',`
@@ -42,7 +42,6 @@ RUN cp -r /opt/intel/openvino/data_processing/dl_streamer/lib/* BUILD_DESTDIR/us
 
 RUN mkdir -p BUILD_DESTDIR/opt/intel/dl_streamer/python && \
     cp -r /opt/intel/openvino/data_processing/dl_streamer/python/* BUILD_DESTDIR/opt/intel/dl_streamer/python
-
 ')dnl
 
 define(`INSTALL_GVA',

--- a/template/components/vcaca-gst-gva.m4
+++ b/template/components/vcaca-gst-gva.m4
@@ -42,6 +42,7 @@ RUN cp -r /opt/intel/openvino/data_processing/dl_streamer/lib/* BUILD_DESTDIR/us
 
 RUN mkdir -p BUILD_DESTDIR/opt/intel/dl_streamer/python && \
     cp -r /opt/intel/openvino/data_processing/dl_streamer/python/* BUILD_DESTDIR/opt/intel/dl_streamer/python
+
 ')dnl
 
 define(`INSTALL_GVA',

--- a/test/dldt_ffmpeg_video_analytics_vcaca.sh
+++ b/test/dldt_ffmpeg_video_analytics_vcaca.sh
@@ -9,12 +9,14 @@ else
   apt-get install -y wget make python3 python3-pip
   if grep --quiet 'Ubuntu 18' /etc/os-release; then
     apt-get install -y libjson-c3
+  elif grep --quiet 'Ubuntu 20' /etc/os-release; then
+    apt-get install -y libjson-c4
   fi
 fi
 
 pip3 install pyyaml requests
 
-if grep --quiet 'Ubuntu 18' /etc/os-release; then
+if grep --quiet 'Ubuntu' /etc/os-release; then
   wget https://download.01.org/opencv/2021/openvinotoolkit/2021.1/open_model_zoo/models_bin/2/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.xml
   wget https://download.01.org/opencv/2021/openvinotoolkit/2021.1/open_model_zoo/models_bin/2/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.bin
   wget https://download.01.org/opencv/2021/openvinotoolkit/2021.1/open_model_zoo/models_bin/2/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.bin

--- a/test/dldt_gst_video_analytics.sh
+++ b/test/dldt_gst_video_analytics.sh
@@ -11,7 +11,7 @@ fi
 
 pip3 install pyyaml requests
 
-if grep --quiet 'Ubuntu 18' /etc/os-release; then
+if grep --quiet 'Ubuntu' /etc/os-release; then
   wget https://download.01.org/opencv/2021/openvinotoolkit/2021.1/open_model_zoo/models_bin/2/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.bin
   wget https://download.01.org/opencv/2021/openvinotoolkit/2021.1/open_model_zoo/models_bin/2/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.xml
   wget https://raw.githubusercontent.com/openvinotoolkit/dlstreamer_gst/master/samples/model_proc/vehicle-license-plate-detection-barrier-0106.json

--- a/test/dldt_gst_video_analytics_vcaca.sh
+++ b/test/dldt_gst_video_analytics_vcaca.sh
@@ -11,7 +11,7 @@ fi
 
 pip3 install pyyaml requests
 
-if grep --quiet 'Ubuntu 18' /etc/os-release; then
+if grep --quiet 'Ubuntu' /etc/os-release; then
   wget https://download.01.org/opencv/2021/openvinotoolkit/2021.1/open_model_zoo/models_bin/2/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.bin
   wget https://download.01.org/opencv/2021/openvinotoolkit/2021.1/open_model_zoo/models_bin/2/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.xml
   wget https://raw.githubusercontent.com/openvinotoolkit/dlstreamer_gst/master/samples/model_proc/vehicle-license-plate-detection-barrier-0106.json


### PR DESCRIPTION
Ubuntu20.04 still wont work for gvapython as *.typelibs are missing. But working with IAGS for that